### PR TITLE
Modify response rendering to include status code

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -145,11 +145,8 @@ class ProjectsController < ApplicationController
       request.body = URI.encode_www_form(post_params)
       http.request(request)
     end
-    if response.is_a?(Net::HTTPSuccess)
-      render html: response.body.html_safe
-    else
-      render plain: "Preview build failed", status: :bad_gateway
-    end
+    # return html along with the status returned by build server
+    render html: response.body.html_safe, status: response.code
   rescue Net::OpenTimeout, Net::ReadTimeout
     render plain: "Preview build timed out", status: :gateway_timeout
   rescue SocketError, EOFError, IOError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SystemCallError

--- a/test/test_helpers/session_test_helper.rb
+++ b/test/test_helpers/session_test_helper.rb
@@ -16,6 +16,12 @@ module BuildServerHelper
     fake_response = Struct.new(:body).new(body)
     fake_response.define_singleton_method(:is_a?) { |klass| klass == Net::HTTPSuccess }
 
+    if raise_error
+      fake_response.define_singleton_method(:code) { |_| "500" }
+    else
+      fake_response.define_singleton_method(:code) { |_| "200" }
+    end
+
     fake_http = Object.new
     fake_http.define_singleton_method(:request) { |_req| fake_response }
 

--- a/test/test_helpers/session_test_helper.rb
+++ b/test/test_helpers/session_test_helper.rb
@@ -17,9 +17,9 @@ module BuildServerHelper
     fake_response.define_singleton_method(:is_a?) { |klass| klass == Net::HTTPSuccess }
 
     if raise_error
-      fake_response.define_singleton_method(:code) { |_| "500" }
+      fake_response.define_singleton_method(:code) { "500" }
     else
-      fake_response.define_singleton_method(:code) { |_| "200" }
+      fake_response.define_singleton_method(:code) { "200" }
     end
 
     fake_http = Object.new


### PR DESCRIPTION
Closes #119 

We want to return whatever the build server returns (in particular we want to return the error messages).