### PR TITLE
Implement common docinfo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,3 +99,10 @@ Authorization is inline (no Pundit/CanCan):
 - **Mailers use `deliver_later`** and go through the Resend API (configured in `config/initializers/mailer.rb`)
 - **Project build** happens in `Project#before_save` — modifying `content` or `title` triggers an HTTP call to the build server
 - **Sharing:** Projects have a public `/projects/:id/share` route (no auth required) and a copy-to-account feature gated to sustaining/admin users
+
+### Transaction Safety Pattern
+
+- In transaction blocks that perform writes, use bang methods (`save!`, `update!`, `create!`) or explicitly raise on failure.
+- Do not rely on non-bang return values for multi-write transaction success.
+- Prefer rescuing `ActiveRecord::RecordInvalid` and returning `e.record.errors` so failures point to the exact model that failed.
+- Keep payload/serialization shape in models when possible (for example, `Project#to_h`) rather than composing payloads in controllers.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,12 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+require:
+  - ./lib/rubocop/cop/pretext_plus/transaction_requires_bang_writes.rb
+
+PretextPlus/TransactionRequiresBangWrites:
+  Enabled: true
+
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/Privacy Policy.md
+++ b/Privacy Policy.md
@@ -1,0 +1,195 @@
+# Privacy Policy
+
+Last updated: April 22, 2026
+
+PreTeXt.Plus ("PreTeXt.Plus," "we," "us," or "our") provides an online platform for authoring, compiling, and sharing technical documents, including mathematical content. This Privacy Policy explains how we collect, use, disclose, and protect personal information when you use our website, applications, and related services (collectively, the "Service").
+
+By creating an account or using the Service, you acknowledge this Privacy Policy.
+
+## 1. Scope
+
+This Privacy Policy applies to personal information we process as a data controller in connection with the Service. It does not apply to third-party websites, platforms, or services that we do not control.
+
+## 2. Information We Collect
+
+We collect the following categories of information.
+
+### 2.1 Account and identity information
+
+- Email address
+- Name or display name, if you provide one
+- Account credentials (passwords are stored only as secure hashes)
+- Account settings, subscription tier, and account status
+
+### 2.2 Session, security, and technical information
+
+- Session identifiers and authentication cookies
+- IP address and user agent associated with sessions
+- Device and browser details
+- Logs related to service health, abuse prevention, and security events
+
+### 2.3 Project and content information
+
+- Project titles, source content, and metadata
+- Generated HTML output and related build metadata
+- Sharing state for projects, including public share links
+
+### 2.4 Invitation and request information
+
+- Invitation codes and redemption status
+- Invitation sender/recipient metadata
+- Access request submissions
+
+### 2.5 Billing information
+
+- Subscription status and billing events
+- Limited billing metadata from our payment processor (Stripe)
+
+We do not store full payment card numbers.
+
+### 2.6 Communication information
+
+- Transactional emails (for example: invitations, password reset, billing notices)
+- Email delivery metadata from our email provider
+
+## 3. How We Use Personal Information
+
+We use personal information to:
+
+- Provide, operate, and maintain the Service
+- Create and secure user accounts and sessions
+- Process, compile, and deliver project outputs
+- Enforce plan limits and account entitlements
+- Send transactional and administrative communications
+- Process subscriptions and billing workflows
+- Monitor, detect, and prevent fraud, abuse, and security incidents
+- Comply with legal obligations and enforce agreements
+- Improve Service performance, reliability, and product quality
+
+## 4. Public Sharing and Visibility
+
+The Service supports project sharing via public share links. If you create or enable a public share link, content at that link may be accessible to anyone who has the URL. You are responsible for the data you choose to publish through sharing features.
+
+## 5. Legal Bases for Processing (EEA/UK)
+
+For individuals in the EEA, UK, or similar jurisdictions, our legal bases include:
+
+- Contract: processing necessary to provide the Service you request
+- Legitimate interests: security, fraud prevention, troubleshooting, service improvement, and core operations
+- Legal obligation: compliance with applicable laws and lawful requests
+- Consent: where required by law, including certain non-essential cookies or communications
+
+You may withdraw consent at any time where processing is based on consent.
+
+## 6. Cookies and Similar Technologies
+
+We use cookies and similar technologies to:
+
+- Keep you signed in and maintain secure sessions
+- Support core site functionality
+- Protect accounts and infrastructure
+
+Where required, we obtain consent before using non-essential cookies. You can control cookies through your browser settings, but disabling essential cookies may affect functionality.
+
+## 7. How We Disclose Personal Information
+
+We may disclose personal information to:
+
+- Infrastructure, hosting, and technical service providers
+- Build-processing providers used to compile project content
+- Payment processors (such as Stripe)
+- Email and communication service providers
+- Professional advisors (for legal, accounting, compliance)
+- Government authorities or law enforcement when required by law
+- Successors in connection with a merger, financing, reorganization, or sale
+
+We do not sell personal information for monetary consideration.
+
+## 8. International Data Transfers
+
+We may process personal information in countries other than your own. Where required by law, we use appropriate transfer safeguards, such as contractual commitments designed to protect personal information (for example, Standard Contractual Clauses and, where relevant, the UK Addendum).
+
+## 9. Data Retention
+
+We retain personal information for as long as reasonably necessary to:
+
+- Provide the Service
+- Maintain account history and system integrity
+- Comply with legal, tax, accounting, and regulatory requirements
+- Resolve disputes and enforce agreements
+
+Deletion timelines vary by data type and legal obligations. Backup data may persist for a limited period before deletion in the ordinary backup cycle.
+
+## 10. Security
+
+We use reasonable administrative, technical, and organizational safeguards designed to protect personal information, including transport encryption, access controls, and credential security controls. No method of transmission or storage is completely secure, and we cannot guarantee absolute security.
+
+## 11. Your Privacy Rights
+
+Depending on your jurisdiction, you may have rights to:
+
+- Access personal information we hold about you
+- Correct inaccurate or incomplete information
+- Request deletion of personal information
+- Restrict or object to certain processing
+- Request portability of certain data
+- Withdraw consent where applicable
+- Complain to a supervisory authority
+
+To exercise rights, contact us using the details in Section 15. We may verify your identity before completing your request.
+
+## 12. Additional U.S. State Privacy Disclosures (Including California)
+
+This section applies to residents of California and other U.S. states with comparable privacy laws, as applicable.
+
+### 12.1 Categories of personal information collected
+
+In the preceding 12 months, we have collected categories that may include:
+
+- Identifiers (such as email address, IP address, account ID)
+- Internet or network activity (such as browser and usage logs)
+- Commercial information (such as subscription status and billing metadata)
+- User-generated content (project source content and outputs)
+- Inferences used for security, quality, and service optimization
+
+### 12.2 Purposes for collection and use
+
+We collect and use these categories for the business and commercial purposes described in Section 3.
+
+### 12.3 Categories of recipients
+
+We disclose personal information to the categories listed in Section 7.
+
+### 12.4 Sale, sharing, and targeted advertising
+
+We do not sell personal information for monetary consideration.
+
+We do not share personal information for cross-context behavioral advertising as those terms are defined under California law.
+
+### 12.5 Sensitive personal information
+
+We do not use or disclose sensitive personal information for purposes requiring a "Limit the Use of My Sensitive Personal Information" right under California law.
+
+### 12.6 California rights
+
+California residents may have rights to know, access, correct, delete, and obtain portability of personal information, and to be free from unlawful discrimination for exercising privacy rights. To submit a request, contact privacy@pretext.plus.
+
+### 12.7 Authorized agents
+
+Authorized agents may submit requests on your behalf where permitted by law. We may require verification of both your identity and the agent's authority.
+
+## 13. Children's Privacy
+
+The Service is not directed to children under 13, and we do not knowingly collect personal information from children in violation of applicable law. If you believe a child provided personal information, contact us so we can take appropriate action.
+
+## 14. Changes to This Privacy Policy
+
+We may update this Privacy Policy periodically. If we make material changes, we will update the "Last updated" date and provide notice as required by law.
+
+## 15. Contact Us
+
+PreTeXt.Plus
+
+Privacy email: privacy@pretext.plus
+
+Legal email: legal@pretext.plus

--- a/Terms of Service.md
+++ b/Terms of Service.md
@@ -1,0 +1,141 @@
+# Terms of Service
+
+Effective date: April 22, 2026
+
+These Terms of Service ("Terms") are a binding agreement between you and PreTeXt.Plus ("PreTeXt.Plus," "we," "us," or "our") governing your access to and use of our website, applications, and related services (collectively, the "Service").
+
+By creating an account, accessing, or using the Service, you agree to these Terms. If you do not agree, do not use the Service.
+
+## 1. Eligibility and Account Registration
+
+- You must be legally capable of entering into a binding contract.
+- You must provide accurate registration information and keep it current.
+- You are responsible for safeguarding account credentials and for all activity under your account.
+- We may offer the Service on an invitation-only basis or with limited eligibility.
+
+## 2. The Service
+
+The Service enables users to create, edit, compile, and share technical and educational content. Features and access levels may vary by plan.
+
+We may modify, suspend, or discontinue all or part of the Service at any time. Where required by law, we will provide notice.
+
+## 3. User Content
+
+### 3.1 Ownership
+
+You retain ownership of content you upload, create, or otherwise submit through the Service ("User Content").
+
+### 3.2 License to PreTeXt.Plus
+
+You grant us a worldwide, non-exclusive, royalty-free license to host, store, reproduce, process, transmit, display, and create derivative technical transformations of User Content solely as necessary to operate, maintain, secure, and improve the Service.
+
+### 3.3 Public sharing
+
+If you publish or share content through public share links, you understand that such content may be accessible to anyone with the link.
+
+### 3.4 Your responsibilities
+
+You represent and warrant that:
+
+- You have all rights needed to submit and share User Content.
+- Your User Content and use of the Service do not violate law or third-party rights.
+
+## 4. Acceptable Use
+
+You must not:
+
+- Violate any applicable law, regulation, or court order.
+- Upload malware, malicious scripts, or harmful code.
+- Attempt unauthorized access to systems, data, or accounts.
+- Interfere with Service operation, reliability, or security.
+- Infringe intellectual property, privacy, or other rights.
+- Use the Service for fraudulent, deceptive, abusive, or unlawful purposes.
+
+We may investigate violations and take action, including content removal, suspension, or termination.
+
+## 5. Subscriptions, Fees, and Billing
+
+- Some features require a paid subscription.
+- Payments are processed by third-party providers (including Stripe) under their terms.
+- Subscription fees are billed as disclosed at checkout or in your account.
+- Unless otherwise stated, subscriptions renew automatically until canceled.
+- You may cancel through your billing settings or payment portal; cancellation takes effect at the end of the current billing period unless otherwise stated.
+- Fees already paid are non-refundable except as required by law.
+
+We may change pricing, plans, quotas, or feature access in the future with notice required by law.
+
+## 6. Service Limits and Administration
+
+We may enforce plan limits, quotas, and fair-use controls (for example, project limits, build limits, and anti-abuse protections). We may access account content when reasonably necessary for support, security, abuse prevention, legal compliance, and service operations.
+
+## 7. Third-Party Services
+
+The Service relies on third-party providers for infrastructure, payment processing, email delivery, and content build/compilation workflows. We are not responsible for third-party services except as required by law.
+
+## 8. Intellectual Property
+
+Except for User Content and third-party materials, the Service and all related software, designs, trademarks, and content are owned by PreTeXt.Plus or its licensors and protected by intellectual property laws.
+
+No rights are granted except those expressly provided in these Terms.
+
+## 9. Suspension and Termination
+
+### 9.1 By you
+
+You may stop using the Service at any time and may request account deletion.
+
+### 9.2 By us
+
+We may suspend or terminate access if:
+
+- You breach these Terms,
+- Your use creates legal or security risk,
+- It is necessary to protect the Service, users, or third parties.
+
+### 9.3 Effect
+
+Upon termination, your right to use the Service ends. Sections that by nature should survive termination will survive, including ownership, disclaimers, limitations of liability, indemnity, and dispute provisions.
+
+## 10. Disclaimers
+
+To the maximum extent permitted by law, the Service is provided "as is" and "as available" without warranties of any kind, express or implied, including warranties of merchantability, fitness for a particular purpose, non-infringement, and uninterrupted availability.
+
+## 11. Limitation of Liability
+
+To the maximum extent permitted by law:
+
+- We are not liable for indirect, incidental, special, consequential, exemplary, or punitive damages, or for lost profits, revenues, data, goodwill, or business opportunities.
+- Our total liability for all claims relating to the Service and these Terms will not exceed the greater of:
+  - the amount you paid to us in the 12 months before the event giving rise to liability, or
+  - USD $100.
+
+Some jurisdictions do not allow certain limitations, so portions of this section may not apply to you.
+
+## 12. Indemnification
+
+You agree to defend, indemnify, and hold harmless PreTeXt.Plus and its affiliates, officers, directors, employees, and agents from and against claims, losses, liabilities, damages, judgments, and expenses (including reasonable attorneys' fees) arising out of or relating to:
+
+- Your use of the Service,
+- Your User Content,
+- Your violation of these Terms or applicable law,
+- Your infringement of third-party rights.
+
+## 13. Governing Law and Venue
+
+These Terms are governed by the laws of the State of Delaware, without regard to conflict-of-law principles. Any dispute not subject to arbitration must be brought exclusively in the state or federal courts located in Delaware, and each party consents to personal jurisdiction and venue in those courts.
+
+## 14. Informal Dispute Resolution
+
+Before filing a legal claim, you agree to first contact legal@pretext.plus and attempt to resolve the dispute informally for at least 30 days, unless prohibited by law.
+
+## 15. Changes to These Terms
+
+We may update these Terms from time to time. If we make material changes, we will post the updated Terms and revise the effective date. Your continued use of the Service after the updated Terms become effective constitutes acceptance.
+
+## 16. Contact Information
+
+PreTeXt.Plus
+
+Legal contact: legal@pretext.plus
+
+Privacy contact: privacy@pretext.plus

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -142,7 +142,7 @@ class ProjectsController < ApplicationController
 
   # GET /projects/:id/editor_state
   def editor_state
-    render json: editor_state_payload
+    render json: @project.to_h
   end
 
   # PATCH /projects/:id/editor_state
@@ -150,22 +150,14 @@ class ProjectsController < ApplicationController
     attrs = editor_state_params.to_h.symbolize_keys
     common_docinfo = attrs.delete(:common_docinfo)
 
-    updated = ActiveRecord::Base.transaction do
-      if !common_docinfo.nil?
-        @project.user.update(common_docinfo: common_docinfo)
-      else
-        true
-      end
-      @project.update(attrs)
+    ActiveRecord::Base.transaction do
+      @project.user.update!(common_docinfo: common_docinfo) unless common_docinfo.nil?
+      @project.update!(attrs)
     end
 
-    if updated
-      render json: editor_state_payload
-    else
-      errors = @project.errors
-      errors = @project.user.errors if errors.empty?
-      render json: { errors: errors }, status: :unprocessable_entity
-    end
+    render json: @project.to_h
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { errors: e.record.errors }, status: :unprocessable_entity
   end
 
   def share
@@ -269,10 +261,6 @@ class ProjectsController < ApplicationController
 
     def editor_state_params
       params.expect(project: [ :title, :source, :pretext_source, :source_format, :docinfo, :use_common_docinfo, :common_docinfo ])
-    end
-
-    def editor_state_payload
-      @project.to_h.merge(common_docinfo: @project.user.common_docinfo)
     end
 
     # redirect if user has too many projects

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -142,15 +142,29 @@ class ProjectsController < ApplicationController
 
   # GET /projects/:id/editor_state
   def editor_state
-    render json: @project.to_h
+    render json: editor_state_payload
   end
 
   # PATCH /projects/:id/editor_state
   def update_editor_state
-    if @project.update(project_params)
-      render json: @project.to_h
+    attrs = editor_state_params.to_h.symbolize_keys
+    common_docinfo = attrs.delete(:common_docinfo)
+
+    updated = ActiveRecord::Base.transaction do
+      if !common_docinfo.nil?
+        @project.user.update(common_docinfo: common_docinfo)
+      else
+        true
+      end
+      @project.update(attrs)
+    end
+
+    if updated
+      render json: editor_state_payload
     else
-      render json: { errors: @project.errors }, status: :unprocessable_entity
+      errors = @project.errors
+      errors = @project.user.errors if errors.empty?
+      render json: { errors: errors }, status: :unprocessable_entity
     end
   end
 
@@ -250,7 +264,15 @@ class ProjectsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def project_params
-      params.expect(project: [ :title, :source, :pretext_source, :source_format, :docinfo ])
+      params.expect(project: [ :title, :source, :pretext_source, :source_format, :docinfo, :use_common_docinfo ])
+    end
+
+    def editor_state_params
+      params.expect(project: [ :title, :source, :pretext_source, :source_format, :docinfo, :use_common_docinfo, :common_docinfo ])
+    end
+
+    def editor_state_payload
+      @project.to_h.merge(common_docinfo: @project.user.common_docinfo)
     end
 
     # redirect if user has too many projects

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
   end
 
   def update_params
-    ps = params.expect(user: [ :name, :password ])
+    ps = params.expect(user: [ :name, :password, :common_docinfo ])
     if ps[:password].blank?
       return ps.except(:password)
     end

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -34,6 +34,8 @@ export default class extends Controller {
       sourceFormat: state.source_format ?? "pretext",
       pretextSource: state.pretext_source ?? "",
       docinfo: state.docinfo ?? "",
+      commonDocinfo: state.common_docinfo ?? "",
+      useCommonDocinfo: state.use_common_docinfo ?? false,
     };
     const saved = { ...current };
 
@@ -41,7 +43,9 @@ export default class extends Controller {
       current.source !== saved.source ||
       current.title !== saved.title ||
       current.pretextSource !== saved.pretextSource ||
-      current.docinfo !== saved.docinfo;
+      current.docinfo !== saved.docinfo ||
+      current.commonDocinfo !== saved.commonDocinfo ||
+      current.useCommonDocinfo !== saved.useCommonDocinfo;
 
     const onSave = async (force = false) => {
       if (!force && !isDirty()) return true;
@@ -61,6 +65,8 @@ export default class extends Controller {
               source_format: current.sourceFormat,
               pretext_source: current.pretextSource,
               docinfo: current.docinfo,
+              use_common_docinfo: current.useCommonDocinfo,
+              common_docinfo: current.commonDocinfo,
             }
           }),
         });
@@ -98,12 +104,16 @@ export default class extends Controller {
       if (current.sourceFormat !== "pretext") {
         current.pretextSource = content ?? "";
       }
+      // Use the common docinfo when the project is set to use it.
+      const effectiveDocinfo = current.useCommonDocinfo && current.commonDocinfo
+        ? current.commonDocinfo
+        : current.docinfo;
       const assembledSource = assemblePreviewSource({
         content,
         title: current.title,
         sourceFormat: current.sourceFormat,
         pretextSource: current.pretextSource,
-        docinfo: current.docinfo,
+        docinfo: effectiveDocinfo,
       });
       postToIframe("/projects/preview", {
         source: assembledSource,
@@ -181,13 +191,19 @@ export default class extends Controller {
       sourceFormat: current.sourceFormat,
       pretextSource: current.pretextSource || undefined,
       docinfo: current.docinfo || undefined,
+      commonDocinfo: current.commonDocinfo || undefined,
+      useCommonDocinfo: current.useCommonDocinfo,
       onContentChange: (v, meta) => {
         current.source = v ?? "";
         if (meta?.sourceFormat) current.sourceFormat = meta.sourceFormat;
         if (meta?.pretextSource !== undefined) current.pretextSource = meta.pretextSource;
         // docinfo changes are delivered via meta when the DocinfoEditor saves
         if (meta?.docinfo !== undefined) current.docinfo = meta.docinfo;
+        if (meta?.commonDocinfo !== undefined) current.commonDocinfo = meta.commonDocinfo;
+        if (meta?.useCommonDocinfo !== undefined) current.useCommonDocinfo = meta.useCommonDocinfo;
       },
+      onCommonDocinfoChange: (value) => { current.commonDocinfo = value ?? ""; onSave(); },
+      onUseCommonDocinfoChange: (value) => { current.useCommonDocinfo = value === true; onSave(); },
       title: current.title,
       onTitleChange: (v) => { current.title = v ?? ""; },
       onSaveButton,

--- a/app/javascript/controllers/react/editor.jsx
+++ b/app/javascript/controllers/react/editor.jsx
@@ -12,6 +12,10 @@ function EditorWrapper({ onContentChange, onTitleChange, onCreatePretextProjectC
     sourceFormat: sourceFormatProp,
     pretextSource: pretextSourceProp,
     docinfo: docinfoProp,
+    commonDocinfo: commonDocinfoProp,
+    useCommonDocinfo: useCommonDocinfoProp,
+    onCommonDocinfoChange,
+    onUseCommonDocinfoChange,
     ...editorProps
   } = rest;
 
@@ -20,6 +24,8 @@ function EditorWrapper({ onContentChange, onTitleChange, onCreatePretextProjectC
   const [sourceFormat, setSourceFormat] = useState(sourceFormatProp);
   const [pretextSource, setPretextSource] = useState(pretextSourceProp);
   const [docinfo, setDocinfo] = useState(docinfoProp);
+  const [commonDocinfo, setCommonDocinfo] = useState(commonDocinfoProp ?? "");
+  const [useCommonDocinfo, setUseCommonDocinfo] = useState(useCommonDocinfoProp ?? false);
 
   const handleContentChange = useCallback((v, meta) => {
     const nextSource = v ?? meta?.sourceContent ?? "";
@@ -28,6 +34,8 @@ function EditorWrapper({ onContentChange, onTitleChange, onCreatePretextProjectC
     if (meta?.pretextSource !== undefined) setPretextSource(meta.pretextSource);
     // docinfo changes arrive via meta when DocinfoEditor saves inside Editors
     if (meta?.docinfo !== undefined) setDocinfo(meta.docinfo);
+    if (meta?.commonDocinfo !== undefined) setCommonDocinfo(meta.commonDocinfo);
+    if (meta?.useCommonDocinfo !== undefined) setUseCommonDocinfo(meta.useCommonDocinfo);
     onContentChange?.(nextSource, meta);
   }, [onContentChange]);
 
@@ -35,6 +43,18 @@ function EditorWrapper({ onContentChange, onTitleChange, onCreatePretextProjectC
     setTitle(v);
     onTitleChange?.(v);
   }, [onTitleChange]);
+
+  const handleCommonDocinfoChange = useCallback((value) => {
+    const nextValue = value ?? "";
+    setCommonDocinfo(nextValue);
+    onCommonDocinfoChange?.(nextValue);
+  }, [onCommonDocinfoChange]);
+
+  const handleUseCommonDocinfoChange = useCallback((value) => {
+    const nextValue = value === true;
+    setUseCommonDocinfo(nextValue);
+    onUseCommonDocinfoChange?.(nextValue);
+  }, [onUseCommonDocinfoChange]);
 
   return (
     <Editors
@@ -44,8 +64,12 @@ function EditorWrapper({ onContentChange, onTitleChange, onCreatePretextProjectC
       sourceFormat={sourceFormat}
       pretextSource={pretextSource}
       docinfo={docinfo}
+      commonDocinfo={commonDocinfo}
+      useCommonDocinfo={useCommonDocinfo}
       onContentChange={handleContentChange}
       onTitleChange={handleTitleChange}
+      onCommonDocinfoChange={handleCommonDocinfoChange}
+      onUseCommonDocinfoChange={handleUseCommonDocinfoChange}
       onCreatePretextProjectCopy={onCreatePretextProjectCopy}
       onFeedbackSubmit={onFeedbackSubmit}
     />

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -51,8 +51,12 @@ class Project < ApplicationRecord
     self.docinfo = DEFAULT_DOCINFO
   end
 
+  def common_docinfo
+    user.common_docinfo
+  end
+
   def to_h
-    [ :title, :source, :source_format, :pretext_source, :docinfo, :use_common_docinfo ]
+    [ :title, :source, :source_format, :pretext_source, :docinfo, :use_common_docinfo, :common_docinfo ]
       .map { |attr| [ attr, self.send(attr) ] }.to_h
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -16,13 +16,21 @@ class Project < ApplicationRecord
     doc_tag = document_type || "article"
 
     xml = +"<pretext>"
-    xml << docinfo.to_s if docinfo.present?
+    xml << effective_docinfo.to_s if effective_docinfo.present?
     xml << "<#{doc_tag} label=\"article\">"
     xml << "<title>#{title}</title>" if title.present?
     xml << (latex_source_format? ? pretext_source.to_s : source.to_s)
     xml << "</#{doc_tag}>"
     xml << "</pretext>"
     xml
+  end
+
+  def effective_docinfo
+    if use_common_docinfo? && user&.common_docinfo.present?
+      user.common_docinfo
+    else
+      docinfo
+    end
   end
 
   def self.default_docinfo
@@ -44,7 +52,7 @@ class Project < ApplicationRecord
   end
 
   def to_h
-    [ :title, :source, :source_format, :pretext_source, :docinfo ]
+    [ :title, :source, :source_format, :pretext_source, :docinfo, :use_common_docinfo ]
       .map { |attr| [ attr, self.send(attr) ] }.to_h
   end
 
@@ -60,9 +68,9 @@ class Project < ApplicationRecord
 
       <p>
         This is a sample project to get you started. You can edit this content using the PreTeXt markup language.
-        <me>
+        <md>
           \\left|\\sum_{i=0}^n a_i\\right|\\leq\\sum_{i=0}^n|a_i|
-        </me>
+        </md>
       </p>
 
       <fact>

--- a/db/migrate/20260425120000_add_common_docinfo_to_users_and_projects.rb
+++ b/db/migrate/20260425120000_add_common_docinfo_to_users_and_projects.rb
@@ -1,0 +1,6 @@
+class AddCommonDocinfoToUsersAndProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :common_docinfo, :text
+    add_column :projects, :use_common_docinfo, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260425223500_set_default_common_docinfo_on_users.rb
+++ b/db/migrate/20260425223500_set_default_common_docinfo_on_users.rb
@@ -1,0 +1,22 @@
+class SetDefaultCommonDocinfoOnUsers < ActiveRecord::Migration[8.1]
+  DEFAULT_DOCINFO = <<~XML
+    <docinfo>
+      <brandlogo source="icon.svg" />
+    </docinfo>
+  XML
+
+  def up
+    change_column_default :users, :common_docinfo, from: nil, to: DEFAULT_DOCINFO
+
+    quoted_default = connection.quote(DEFAULT_DOCINFO)
+    execute <<~SQL
+      UPDATE users
+      SET common_docinfo = #{quoted_default}
+      WHERE common_docinfo IS NULL
+    SQL
+  end
+
+  def down
+    change_column_default :users, :common_docinfo, from: DEFAULT_DOCINFO, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_212159) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_25_223500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -136,6 +136,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_212159) do
     t.integer "source_format", default: 0, null: false
     t.string "title"
     t.datetime "updated_at", null: false
+    t.boolean "use_common_docinfo", default: false, null: false
     t.uuid "user_id", null: false
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
@@ -154,6 +155,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_212159) do
     t.string "user_agent"
     t.uuid "user_id", null: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "source_elements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "element_type", null: false
+    t.uuid "parent_id"
+    t.integer "position", default: 0, null: false
+    t.text "pretext_source"
+    t.uuid "project_id", null: false
+    t.text "source"
+    t.integer "source_format", default: 0, null: false
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["parent_id"], name: "index_source_elements_on_parent_id"
+    t.index ["project_id", "parent_id", "position"], name: "index_source_elements_on_project_id_and_parent_id_and_position"
+    t.index ["project_id"], name: "index_source_elements_on_project_id"
   end
 
   create_table "subscription_seats", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -178,6 +195,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_212159) do
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "admin", default: false
+    t.text "common_docinfo", default: "<docinfo>\n  <brandlogo source=\"icon.svg\" />\n</docinfo>\n"
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.string "name"
@@ -198,6 +216,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_212159) do
   add_foreign_key "projects", "users"
   add_foreign_key "requests", "users"
   add_foreign_key "sessions", "users"
+  add_foreign_key "source_elements", "projects"
+  add_foreign_key "source_elements", "source_elements", column: "parent_id"
   add_foreign_key "subscription_seats", "pay_subscriptions"
   add_foreign_key "subscription_seats", "users"
 end

--- a/lib/rubocop/cop/pretext_plus/transaction_requires_bang_writes.rb
+++ b/lib/rubocop/cop/pretext_plus/transaction_requires_bang_writes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module PretextPlus
+      # Flags non-bang ActiveRecord writes inside transaction blocks.
+      #
+      # In a transaction, methods like update/save can fail without raising,
+      # which prevents automatic rollback. Require bang variants so failures
+      # raise and rollback the transaction.
+      class TransactionRequiresBangWrites < Base
+        MSG = "Use bang write methods inside transactions (for example update!, save!, create!) so failures raise and rollback."
+
+        RESTRICT_ON_SEND = [ :transaction ].freeze
+        NON_BANG_WRITES = %i[
+          save
+          update
+          update_attributes
+          create
+          create_or_find_by
+          create_with
+          first_or_create
+          first_or_create!
+          find_or_create_by
+          find_or_initialize_by
+        ].freeze
+
+        def on_send(node)
+          return unless node.method?(:transaction)
+
+          block = node.each_ancestor(:block).first
+          return unless block && block.send_node == node
+
+          block.body&.each_descendant(:send)&.each do |send_node|
+            method_name = send_node.method_name
+            next unless NON_BANG_WRITES.include?(method_name)
+
+            add_offense(send_node.loc.selector)
+          end
+        end
+      end
+    end
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.20",
-        "@pretextbook/web-editor": "^0.0.32",
+        "@pretextbook/web-editor": "^0.0.33",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@pretextbook/web-editor": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@pretextbook/web-editor/-/web-editor-0.0.32.tgz",
-      "integrity": "sha512-Ai8GpmQp/Ziz2BJmsfjMig5wOeAqIzEqP/z34kkEhhYKdgSCMuXlosv6RDNMtOX9jaCywSxitj0neIr68InPeQ==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@pretextbook/web-editor/-/web-editor-0.0.33.tgz",
+      "integrity": "sha512-OztGhjaP9zPyTGp9W9Jp6k717qNw98ndODNNjvzo0Rt3cHX7H39HcdbHcMChkLThB+6r5NJs2q+HBQ7ey2nGQg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
-    "@pretextbook/web-editor": "^0.0.32",
+    "@pretextbook/web-editor": "^0.0.33",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -256,6 +256,8 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_includes json.keys, "source_format"
     assert_includes json.keys, "pretext_source"
     assert_includes json.keys, "docinfo"
+    assert_includes json.keys, "use_common_docinfo"
+    assert_includes json.keys, "common_docinfo"
   end
 
   test "editor_state includes docinfo value" do
@@ -269,7 +271,15 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   test "should update_editor_state via patch" do
     stub_build_server do
       patch editor_state_project_url(@project),
-        params: { project: { title: "API Title", source: "new source", docinfo: "<docinfo/>" } },
+        params: {
+          project: {
+            title: "API Title",
+            source: "new source",
+            docinfo: "<docinfo/>",
+            use_common_docinfo: true,
+            common_docinfo: "<docinfo><macros>\\newcommand{\\N}{\\mathbb{N}}</macros></docinfo>"
+          }
+        },
         as: :json
     end
     assert_response :success
@@ -277,6 +287,19 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "API Title", json["title"]
     assert_equal "API Title", @project.reload.title
     assert_equal "<docinfo/>", @project.docinfo
+    assert_equal true, @project.use_common_docinfo
+    assert_equal "<docinfo><macros>\\newcommand{\\N}{\\mathbb{N}}</macros></docinfo>", @project.user.reload.common_docinfo
+  end
+
+  test "editor_state includes user common_docinfo and project use_common_docinfo" do
+    @project.user.update_column(:common_docinfo, "<docinfo><macros>\\newcommand{\\R}{\\mathbb{R}}</macros></docinfo>")
+    @project.update_column(:use_common_docinfo, true)
+
+    get editor_state_project_url(@project), headers: { "Accept" => "application/json" }
+    json = response.parsed_body
+
+    assert_equal true, json["use_common_docinfo"]
+    assert_equal "<docinfo><macros>\\newcommand{\\R}{\\mathbb{R}}</macros></docinfo>", json["common_docinfo"]
   end
 
   test "docinfo-only editor_state update triggers rebuild" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -40,4 +40,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to projects_path
     assert_equal "Updated Name", users(:one).reload.name
   end
+
+  test "update changes user common_docinfo" do
+    sign_in_as(users(:one))
+    docinfo = "<docinfo><macros>\\newcommand{\\Q}{\\mathbb{Q}}</macros></docinfo>"
+
+    patch user_path(users(:one)), params: { user: { common_docinfo: docinfo } }
+
+    assert_redirected_to projects_path
+    assert_equal docinfo, users(:one).reload.common_docinfo
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -89,4 +89,13 @@ class UserTest < ActiveSupport::TestCase
 
     assert_equal new_user, invitation.reload.recipient_user
   end
+
+  test "new users get default common_docinfo" do
+    user = User.create!(
+      email: "defaults@example.com",
+      password: "secret123"
+    )
+
+    assert_equal Project.default_docinfo, user.reload.common_docinfo
+  end
 end


### PR DESCRIPTION
Will close #159.  A user can either have a docinfo specific to their project, or select to use their common docinfo (which they can edit from any project that uses it).  They can also just import their common docinfo into their per-project versions if they want to edit it further.

If this looks good to you @StevenClontz, it should be ready to merge as far as I'm concerned. 