### PR TITLE
Try-it improvements

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,7 +53,7 @@ class ProjectsController < ApplicationController
         This is a Markdown-style PreTeXt demo project. You can edit this content using supported Markdown syntax.
 
         $$
-          \left|\sum_{i=0}^n a_i\right| \leq \sum_{i=0}^n |a_i|
+          \\left|\\sum_{i=0}^n a_i\\right|\\leq\\sum_{i=0}^n |a_i|
         $$
 
         When you preview the changes, the source is first converted to PreTeXt and then rendered as accessible HTML.#{' '}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,10 +27,10 @@ class ProjectsController < ApplicationController
 
   # GET /tryit
   def tryit
-    @demo_mode = params[:demo] == "latex" ? "latex" :
-      params[:demo] == "markdown" ? "markdown" : "pretext"
+    @demo_mode = params[:demo] == "pretext" ? "pretext" :
+      params[:demo] == "markdown" ? "markdown" : "latex"
     @title = @demo_mode == "latex" ? "Try LaTeX-style PreTeXt!" :
-      @demo_mode == "markdown" ? "Try Markdown-style PreTeXt!" : "Try it!"
+      @demo_mode == "markdown" ? "Try Markdown-style PreTeXt!" : "Try Classic PreTeXt!"
 
     @content = if @demo_mode == "latex"
       <<~EOS

--- a/app/views/projects/tryit.html.erb
+++ b/app/views/projects/tryit.html.erb
@@ -11,9 +11,9 @@
           <span>Try it Demo</span>
 
       <span class="text-sm font-medium text-sky-900 ml-3">Mode:</span>
-      <%= link_to "PreTeXt", tryit_path(demo: :pretext), class: ["rounded-md px-3 py-1.5 text-sm font-medium", (@demo_mode == "pretext" ? "bg-sky-700 text-white" : "bg-white text-sky-800 border border-sky-300 hover:bg-sky-100")].join(" ") %>
       <%= link_to "LaTeX-style PreTeXt", tryit_path(demo: :latex), class: ["rounded-md px-3 py-1.5 text-sm font-medium", (@demo_mode == "latex" ? "bg-sky-700 text-white" : "bg-white text-sky-800 border border-sky-300 hover:bg-sky-100")].join(" ") %>
       <%= link_to "Markdown-style PreTeXt", tryit_path(demo: :markdown), class: ["rounded-md px-3 py-1.5 text-sm font-medium", (@demo_mode == "markdown" ? "bg-sky-700 text-white" : "bg-white text-sky-800 border border-sky-300 hover:bg-sky-100")].join(" ") %>
+      <%= link_to "Classic PreTeXt", tryit_path(demo: :pretext), class: ["rounded-md px-3 py-1.5 text-sm font-medium", (@demo_mode == "pretext" ? "bg-sky-700 text-white" : "bg-white text-sky-800 border border-sky-300 hover:bg-sky-100")].join(" ") %>
       </h1>
       </div>
       <div class="flex flex-wrap gap-2">

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -209,23 +209,23 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :gateway_timeout
   end
 
-  test "tryit defaults to pretext demo" do
+  test "tryit defaults to latex-style pretext demo" do
     delete session_path
     get tryit_url
 
     assert_response :success
     assert_includes response.body, "Demo"
     assert_includes response.body, "data-tryit-target=\"sourceFormatField\""
-    assert_includes response.body, "value=\"pretext\""
+    assert_includes response.body, "value=\"latex\""
   end
 
-  test "tryit supports latex demo" do
+  test "tryit supports markdown demo" do
     delete session_path
-    get tryit_url, params: { demo: "latex" }
+    get tryit_url, params: { demo: "markdown" }
 
     assert_response :success
-    assert_includes response.body, "value=\"latex\""
-    assert_includes response.body, "Try LaTeX-style PreTeXt!"
+    assert_includes response.body, "value=\"markdown\""
+    assert_includes response.body, "Try Markdown-style PreTeXt!"
   end
 
   # --- Docinfo ---


### PR DESCRIPTION
Two commits: 

- First, fix the latex snippet for the markdown file since it needed escaped backslashes
- Second, make LaTeX-style PreTeXt the default demo markup for try-it.  Renamed PreTeXt to "Classic PreTeXt"