### PR TITLE
Improve user confirmation workflow.

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -13,11 +13,12 @@ class Admin::BaseController < ApplicationController
   end
 
   def access_label_for(user)
-    return "Admin" if user.admin?
-    return "Subscribed" if user.subscribed?
-    return "Invited" if @invited_user_lookup&.[](user.id)
-    return "Requested access" if @requested_user_lookup&.[](user.id)
-
-    "Unverified"
+    result = "Admin" if user.admin?
+    result = "Subscribed" if result.blank? && user.subscribed?
+    result = "Invited" if result.blank? && @invited_user_lookup&.[](user.id)
+    result = "Requested access" if result.blank? if @requested_user_lookup&.[](user.id)
+    result = "Not invited" if result.blank?
+    result += " (Unconfirmed)" unless user.confirmed?
+    result
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -8,7 +8,8 @@ class Admin::DashboardController < Admin::BaseController
       { label: "Recent sign-ins", value: User.where("last_sign_in_at >= ?", 7.days.ago).count, detail: "Unique users who signed in within the last 7 days" },
       { label: "Access requests", value: Request.count, detail: "Outstanding invitation requests" },
       { label: "Claimed invitations", value: Invitation.where.not(recipient_user_id: nil).distinct.count(:recipient_user_id), detail: "Users with invitation records" },
-      { label: "Open invitation codes", value: Invitation.where(recipient_user_id: nil).count, detail: "Invite codes not yet claimed" }
+      { label: "Open invitation codes", value: Invitation.where(recipient_user_id: nil).count, detail: "Invite codes not yet claimed" },
+      { label: "Unconfirmed emails", value: User.where(confirmed_at: nil).count, detail: "Accounts that have not confirmed their email" }
     ]
 
     @recent_users = User.where.not(last_sign_in_at: nil).order(last_sign_in_at: :desc).limit(5)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -43,6 +43,7 @@ class Admin::UsersController < Admin::BaseController
     scope = scope.where(id: subscribed_user_ids) if filter_params[:subscribed] == "1"
     scope = scope.where(id: Request.select(:user_id)) if filter_params[:requested] == "1"
     scope = scope.where(id: Invitation.where.not(recipient_user_id: nil).select(:recipient_user_id)) if filter_params[:invited] == "1"
+    scope = scope.where(confirmed_at: nil) if filter_params[:unconfirmed] == "1"
 
     scope.order(Arel.sql("users.last_sign_in_at DESC NULLS LAST, users.created_at DESC"))
   end
@@ -55,6 +56,6 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def filter_params
-    params.permit(:q, :admins_only, :subscribed, :requested, :invited)
+    params.permit(:q, :admins_only, :subscribed, :requested, :invited, :unconfirmed)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
-  before_action :set_user, only: :show
+  before_action :set_user, only: %i[show confirm]
 
   def index
     @filters = filter_params.to_h
@@ -17,6 +17,11 @@ class Admin::UsersController < Admin::BaseController
     @requests = Request.where(user: @user).order(created_at: :desc)
     @received_invitations = Invitation.where(recipient_user: @user).order(created_at: :desc)
     @owned_invitations = Invitation.where(owner_user: @user).order(created_at: :desc)
+  end
+
+  def confirm
+    @user.confirm
+    redirect_to admin_user_path(@user), notice: "Confirmed #{@user.email}."
   end
 
   private

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <%= form_with url: admin_users_path, method: :get, local: true, class: "mt-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm" do |form| %>
-    <div class="grid gap-4 lg:grid-cols-[minmax(0,2fr)_repeat(4,minmax(0,1fr))]">
+    <div class="grid gap-4 lg:grid-cols-[minmax(0,2fr)_repeat(5,minmax(0,1fr))]">
       <div>
         <%= form.label :q, "Search by name or email", class: "block text-sm font-medium text-gray-700" %>
         <%= form.text_field :q, value: @filters["q"], class: "mt-2 w-full rounded-md border border-gray-300 px-3 py-2 text-sm" %>
@@ -31,6 +31,10 @@
         <%= form.check_box :invited, { checked: @filters["invited"] == "1" }, "1", "0" %>
         Has invitation
       </label>
+      <label class="flex items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-700">
+        <%= form.check_box :unconfirmed, { checked: @filters["unconfirmed"] == "1" }, "1", "0" %>
+        Unconfirmed email
+      </label>
     </div>
 
     <div class="mt-4 flex gap-2">
@@ -47,6 +51,7 @@
           <th class="px-4 py-3 font-medium">Access</th>
           <th class="px-4 py-3 font-medium">Projects</th>
           <th class="px-4 py-3 font-medium">Subscription</th>
+          <th class="px-4 py-3 font-medium">Confirmed</th>
           <th class="px-4 py-3 font-medium">Last sign-in</th>
           <th class="px-4 py-3 font-medium">Created</th>
         </tr>
@@ -72,6 +77,13 @@
                 <% end %>
               <% else %>
                 None
+              <% end %>
+            </td>
+            <td class="px-4 py-4 align-top text-gray-700">
+              <% if user.confirmed? %>
+                <span class="rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-800">Confirmed</span>
+              <% else %>
+                <span class="rounded-full bg-yellow-100 px-2.5 py-1 text-xs font-medium text-yellow-800">Unconfirmed</span>
               <% end %>
             </td>
             <td class="px-4 py-4 align-top text-gray-700">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -15,7 +15,7 @@
   <section class="mt-8 grid gap-4 xl:grid-cols-4">
     <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
       <p class="text-sm font-medium uppercase tracking-wide text-gray-500">Access</p>
-      <p class="mt-3 text-2xl font-semibold text-gray-900"><%= access_label_for(@user) %></p>
+      <p class="mt-3 text-lg font-semibold text-gray-900"><%= access_label_for(@user) %></p>
     </div>
     <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
       <p class="text-sm font-medium uppercase tracking-wide text-gray-500">Projects</p>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -107,7 +107,14 @@
         </div>
         <div>
           <dt class="font-medium text-gray-500">Email confirmed</dt>
-          <dd><%= @user.confirmed? ? @user.confirmed_at.to_date : "Not confirmed" %></dd>
+          <dd>
+            <% if @user.confirmed? %>
+              <%= @user.confirmed_at.to_date %>
+            <% else %>
+              Not confirmed
+              <%= button_to "Confirm email", confirm_admin_user_path(@user), method: :post, class: "ml-2 rounded-md px-2.5 py-1 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium cursor-pointer", form_class: "inline-block" %>
+            <% end %>
+          </dd>
         </div>
       </dl>
     </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -4,13 +4,28 @@
   <h1 class="font-bold text-4xl">Resend confirmation email</h1>
   <p class="my-4 text-gray-600">Enter the email address you used to register and we'll send you a new confirmation link.</p>
 
-  <%= form_with(model: resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { turbo: false }) do |form| %>
+  <%= form_with(model: current_user || resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { turbo: false }) do |form| %>
     <div class="my-5">
       <%= form.email_field :email, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
     </div>
 
-    <div class="inline">
-      <%= form.submit "Resend confirmation", class: "w-full sm:w-auto text-center rounded-lg px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+    <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
+      <div class="inline">
+        <%= form.submit "Resend confirmation", class: "w-full sm:w-auto text-center rounded-lg px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+      </div>
+
+      <div class="mt-4 text-sm sm:mt-0">
+        <%= link_to "Register a new account", new_user_path, class: "text-green-700 underline hover:no-underline" %>
+      </div>
+
+      <div class="mt-4 text-sm sm:mt-0">
+        <%= link_to "Sign in", new_user_session_path, class: "text-blue-700 underline hover:no-underline" %>
+      </div>
     </div>
   <% end %>
+  <p class="text-sm my-4 text-gray-500 mx-4">
+    Having trouble finding your confirmation email? Contact your IT team to see if it was blocked by your
+    firewall, or email <a href="mailto:support@pretext.plus" class="text-blue-700 hover:underline">support@pretext.plus</a>
+    to get confirmed manually.
+  </p>
 </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -12,6 +12,15 @@
   </div>
 
   <div id="projects" class="min-w-full space-y-5">
+    <% if current_user.present? and !current_user.confirmed? %>
+      <div class="flex justify-center">
+        <p class="my-2 py-2 px-3 bg-blue-50 border-blue-200 border-1 text-blue-500 rounded-md inline-block">
+          ℹ Your email address has not yet been confirmed. Please
+          <%= link_to "confirm your address", new_user_confirmation_path, class: "font-semibold hover:underline" %>
+          within three days to maintain access.
+        </p>
+      </div>
+    <% end %>
     <% unless current_user.subscribed? %>
       <div class="rounded-lg border-2 border-blue-500 p-4 text-sky-900 mt-6 mx-auto md:w-3/4">
       <% if current_user.invited? %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -16,7 +16,7 @@
       <div class="flex justify-center">
         <p class="my-2 py-2 px-3 bg-blue-50 border-blue-200 border-1 text-blue-500 rounded-md inline-block">
           ℹ Your email address has not yet been confirmed. Please
-          <%= link_to "confirm your address", new_user_confirmation_path, class: "font-semibold hover:underline" %>
+          <%= link_to "confirm your email", new_user_confirmation_path, class: "font-semibold hover:underline" %>
           within three days to maintain access.
         </p>
       </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,5 @@
 Devise.setup do |config|
-  config.mailer_sender = "support@pretext.plus"
+  config.mailer_sender = "signin@mailer.pretext.plus"
 
   require "devise/orm/active_record"
 
@@ -20,4 +20,6 @@ Devise.setup do |config|
   # Inherit our ApplicationMailer for Devise emails so they use the same
   # delivery method (Resend) and layout as other transactional emails.
   config.parent_mailer = "ApplicationMailer"
+
+  config.allow_unconfirmed_access_for = 3.days
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   namespace :admin do
     root "dashboard#show"
-    resources :users, only: %i[index show]
+    resources :users, only: %i[index show] do
+      member do
+        post :confirm
+      end
+    end
     resources :projects, only: %i[show]
     resources :terms, only: %i[new create]
   end

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -39,5 +39,6 @@ class Admin::DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Host health"
     assert_includes response.body, "Local runtime metrics only"
     assert_includes response.body, "Recent sign-ins"
+    assert_includes response.body, "Unconfirmed emails"
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -60,6 +60,42 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Unconfirmed"
   end
 
+  test "shows a confirm button for unconfirmed users" do
+    sign_in @admin
+
+    get admin_user_path(users(:unconfirmed))
+
+    assert_response :success
+    assert_includes response.body, "Confirm email"
+  end
+
+  test "does not show a confirm button for confirmed users" do
+    sign_in @admin
+
+    get admin_user_path(users(:subscribed))
+
+    assert_response :success
+    assert_not_includes response.body, "Confirm email"
+  end
+
+  test "confirms an unconfirmed user" do
+    sign_in @admin
+
+    post confirm_admin_user_path(users(:unconfirmed))
+
+    assert_redirected_to admin_user_path(users(:unconfirmed))
+    assert users(:unconfirmed).reload.confirmed?
+  end
+
+  test "redirects non-admin users from confirm" do
+    sign_in @non_admin
+
+    post confirm_admin_user_path(users(:unconfirmed))
+
+    assert_redirected_to projects_path
+    assert_not users(:unconfirmed).reload.confirmed?
+  end
+
   test "search escapes sql like wildcards" do
     User.create!(email: "test_user@example.com", name: "Exact User", password: "password123", confirmed_at: Time.current)
     User.create!(email: "testxuser@example.com", name: "Wildcard User", password: "password123", confirmed_at: Time.current)

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -49,6 +49,17 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Subscription access"
   end
 
+  test "shows confirmation status and filters unconfirmed users" do
+    sign_in @admin
+
+    get admin_users_path, params: { unconfirmed: "1" }
+
+    assert_response :success
+    assert_includes response.body, users(:unconfirmed).email
+    assert_not_includes response.body, users(:subscribed).email
+    assert_includes response.body, "Unconfirmed"
+  end
+
   test "search escapes sql like wildcards" do
     User.create!(email: "test_user@example.com", name: "Exact User", password: "password123", confirmed_at: Time.current)
     User.create!(email: "testxuser@example.com", name: "Wildcard User", password: "password123", confirmed_at: Time.current)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -17,3 +17,9 @@ subscribed:
   email: subbed@example.com
   encrypted_password: <%= encrypted_password %>
   confirmed_at: <%= 1.year.ago %>
+
+unconfirmed:
+  name: Unconfirmed User
+  email: unconfirmed@example.com
+  encrypted_password: <%= encrypted_password %>
+  confirmed_at:


### PR DESCRIPTION
This should help with user confirmation. We allow a 3 day grace period, we prompt to email support@pretext.plus to manually confirm, and we use a valid email address to match our mailer app (which might help with firewall issues).

Opening as draft as I need to add the ability to confirm via dashboard.