### PR TITLE
Use png image for emails instead of svg

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,6 +7,6 @@ class ApplicationMailer < ActionMailer::Base
   private
 
   def attach_logo
-    attachments.inline["logo.svg"] = File.read(Rails.root.join("app/assets/images/logo.svg"))
+    attachments.inline["logo.png"] = File.binread(Rails.root.join("app/assets/images/logo.png"))
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -16,7 +16,7 @@
             <tr>
               <td class="email-masthead" style="word-break: break-word; font-family: &quot;Nunito Sans&quot;, Helvetica, Arial, sans-serif; font-size: 16px; text-align: center; padding: 25px 0;" align="center">
                 <a href="https://pretext.plus" class="f-fallback email-masthead_name" style="color: #A8AAAF; font-size: 16px; font-weight: bold; text-decoration: none; text-shadow: 0 1px 0 white;">
-                  <%= image_tag attachments['logo.svg'].url, alt: "PreTeXt.Plus Logo", width: 100, height: 100, style: "height: auto; max-width: 100%; border: 0;" %>
+                  <%= image_tag attachments['logo.png'].url, alt: "PreTeXt.Plus Logo", width: 100, height: 100, style: "height: auto; max-width: 100%; border: 0;" %>
                 </a>
               </td>
             </tr>


### PR DESCRIPTION
I think this will fix our dropped emails in outlook issue.  

However, I must be doing something wrong when testing in my codespace because as soon as I log in, I get an error.  Maybe the database isn't set up or migrated correct?  Anyway, I'll work on that separately.