### PR TITLE
add new project paths: from template and import

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -2,4 +2,21 @@ class Admin::ProjectsController < Admin::BaseController
   def show
     @project = Project.includes(:user).find(params[:id])
   end
+
+  # Flag/unflag a project as a template offered on the new-project page, and
+  # edit the short description shown alongside it in the template picker.
+  def update
+    @project = Project.find(params[:id])
+    if @project.update(template_params)
+      redirect_to admin_project_path(@project), notice: "Template settings saved."
+    else
+      redirect_to admin_project_path(@project), alert: @project.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  def template_params
+    params.expect(project: [ :is_template, :template_description ])
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,8 +1,8 @@
 class ProjectsController < ApplicationController
   allow_unauthenticated_access only: %i[ share preview source copy_redirect ]
   require_unauthenticated_access only: %i[ tryit ]
-  before_action :limit_projects, only: %i[ new create copy ]
-  load_and_authorize_resource except: %i[ index new tryit preview feedback copy_redirect ]
+  before_action :limit_projects, only: %i[ new create copy create_from_template create_from_import ]
+  load_and_authorize_resource except: %i[ index new tryit preview feedback copy_redirect create_from_template create_from_import ]
   skip_authorize_resource only: %i[ share ]
   after_action :allow_iframe, only: :share
   rate_limit to: 25, within: 10.minutes, only: :preview,
@@ -22,6 +22,9 @@ class ProjectsController < ApplicationController
   def new
     @project = Project.new(user: current_user)
     @project.divisions.build(is_root: true, ref: "document")
+    # Templates offered in the "Start project from template" modal. Read-only:
+    # picking one duplicates it into the current user's account.
+    @templates = Project.templates
   end
 
   # GET /projects/1/edit
@@ -37,8 +40,41 @@ class ProjectsController < ApplicationController
       if @project.save
         format.html { redirect_to edit_project_path(@project) }
       else
+        # The chooser page needs its template list even on a validation re-render,
+        # since the `new` action body doesn't run on this path.
+        @templates = Project.templates
         format.html { render :new, status: :unprocessable_entity }
       end
+    end
+  end
+
+  # POST /projects/from_template/:template_id
+  # Duplicate a team-curated template into the current user's account.
+  def create_from_template
+    # Only projects actually flagged as templates are copyable here, regardless
+    # of which account owns them.
+    template = Project.templates.find(params[:template_id])
+    project = template.instantiate_for(current_user)
+    if project.save
+      redirect_to edit_project_path(project)
+    else
+      redirect_to new_project_path, alert: "Could not create a project from that template."
+    end
+  end
+
+  # POST /projects/import
+  # Create a project from an @pretextbook/import result (posted as multipart so
+  # asset bytes come through as real uploads). Returns the editor URL as JSON;
+  # the import wizard redirects the browser there.
+  def create_from_import
+    @project = Project.new(import_params)
+    @project.user = current_user
+    @project.title = "Imported Project" if @project.title.blank?
+    @project.set_default_docinfo if @project.docinfo.blank?
+    if @project.save
+      render json: { project_url: edit_project_path(@project) }, status: :created
+    else
+      render json: { errors: @project.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
@@ -143,6 +179,41 @@ class ProjectsController < ApplicationController
         divisions_attributes: [ [ :id, :source, :source_format, :is_root, :ref, :_destroy ] ],
         assets_attributes: [ [ :id, :ref, :kind, :file, :source, :short_description, :description, :title, :_destroy ] ]
       ])
+    end
+
+    # The import wizard posts what @pretextbook/import already emits, in this
+    # controller's own shape (see react/import.jsx), so there is nothing to
+    # rename here. Divisions and assets arrive as brand-new records (no id), so
+    # no id/_destroy is permitted.
+    #
+    # The one thing that can't ride along as JSON is an asset's bytes: they
+    # arrive base64-encoded in `file`, and are decoded back into an
+    # ActiveStorage attachable below.
+    def import_params
+      attrs = params.expect(project: [
+        :title, :docinfo, :document_type,
+        divisions_attributes: [ [ :ref, :source, :source_format, :is_root ] ],
+        assets_attributes: [ [ :ref, :kind, :title, :short_description,
+                               { file: [ :filename, :content_type, :data ] } ] ]
+      ]).to_h.deep_symbolize_keys
+
+      if attrs[:assets_attributes].present?
+        attrs[:assets_attributes] = attrs[:assets_attributes].map { |asset| decode_import_asset(asset) }
+      end
+      attrs
+    end
+
+    # Swap an imported asset's base64 `file` object for something ActiveStorage
+    # can attach.
+    def decode_import_asset(asset)
+      file = asset[:file]
+      return asset if file.blank?
+
+      asset.merge(file: {
+        io: StringIO.new(file[:data].to_s.unpack1("m") || ""),
+        filename: file[:filename].presence || asset[:ref].presence || "asset",
+        content_type: file[:content_type].presence || "application/octet-stream"
+      })
     end
 
     def limit_projects

--- a/app/javascript/controllers/import_controller.js
+++ b/app/javascript/controllers/import_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Thin mount point for the React @pretextbook/import wizard used on the
+ * new-project page. Mirrors editor_controller/tryit_controller's mount shape:
+ * dynamically import the React bundle, render into the `root` target, and
+ * unmount on disconnect.
+ *
+ * @extends {Controller}
+ */
+export default class extends Controller {
+  static targets = ["root"]
+  static values = { createUrl: String }
+
+  /** @returns {void} */
+  initialize() {
+    /** @type {Promise<typeof import("./react/import")>} */
+    this.componentPromise = import("./react/import")
+  }
+
+  /** @returns {Promise<void>} */
+  async connect() {
+    this.component = await this.componentPromise
+    this.component.render(this.rootTarget, {
+      createUrl: this.createUrlValue,
+      csrfToken: document.querySelector('meta[name="csrf-token"]')?.content,
+    })
+  }
+
+  /** @returns {void} */
+  disconnect() {
+    this.component?.destroy(this.rootTarget)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,5 +7,11 @@ import { application } from "./application"
 import EditorController from "./editor_controller"
 application.register("editor", EditorController)
 
+import ImportController from "./import_controller"
+application.register("import", ImportController)
+
+import NewProjectController from "./new_project_controller"
+application.register("new-project", NewProjectController)
+
 import TryitController from "./tryit_controller"
 application.register("tryit", TryitController)

--- a/app/javascript/controllers/new_project_controller.js
+++ b/app/javascript/controllers/new_project_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Drives the three-card new-project chooser: each card opens a native
+ * <dialog> (empty-document form, template picker, or import wizard). Dialogs
+ * are matched by a `data-dialog-name` that the card's action param selects.
+ *
+ * @extends {Controller}
+ */
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  connect() {
+    // If the server re-rendered `new` with validation errors (a failed empty-
+    // document create), reopen that dialog so the user sees the messages.
+    if (this.element.dataset.openDialog) {
+      this.showByName(this.element.dataset.openDialog)
+    }
+  }
+
+  /** Open the dialog named by the `dialog` action param. */
+  open(event) {
+    this.showByName(event.params.dialog)
+  }
+
+  /** Close the dialog the clicked control lives in. */
+  close(event) {
+    event.target.closest("dialog")?.close()
+  }
+
+  showByName(name) {
+    const dialog = this.dialogTargets.find((d) => d.dataset.dialogName === name)
+    dialog?.showModal()
+  }
+}

--- a/app/javascript/controllers/react/import.jsx
+++ b/app/javascript/controllers/react/import.jsx
@@ -1,0 +1,83 @@
+import React, { useCallback } from "react";
+import ReactDOM from "react-dom/client";
+import { ImportWizard } from "@pretextbook/import/react";
+import { serializeProjectToPlusPayload } from "@pretextbook/import";
+import "@pretextbook/import/react.css";
+
+/** @typedef {import("@pretextbook/import").ImportedProjectSuccess} ImportedProjectSuccess */
+
+/**
+ * @typedef {Object} ImportConfig
+ * @property {string} createUrl - POST target that creates the project (projects#create_from_import).
+ * @property {string} [csrfToken]
+ */
+
+/**
+ * @param {{ config: ImportConfig }} props
+ * @returns {JSX.Element}
+ */
+function ImportApp({ config }) {
+  const { createUrl, csrfToken } = config;
+
+  // serializeProjectToPlusPayload emits the Rails shape directly -- snake_case
+  // keys matching ProjectsController's permitted `divisions_attributes` /
+  // `assets_attributes`, with asset bytes base64-encoded -- so the payload goes
+  // straight over the same JSON API the editor uses, with nothing to map here.
+  const onConfirm = useCallback(
+    /** @param {ImportedProjectSuccess} result */
+    async (result) => {
+      try {
+        const res = await fetch(createUrl, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "X-CSRF-Token": csrfToken,
+          },
+          body: JSON.stringify({ project: serializeProjectToPlusPayload(result.project) }),
+        });
+        if (!res.ok) {
+          let message = `Import failed: ${res.status}`;
+          try {
+            const err = await res.json();
+            message = err.errors?.join(", ") || err.error || message;
+          } catch {
+            /* non-JSON error body */
+          }
+          throw new Error(message);
+        }
+        const { project_url } = await res.json();
+        window.location.href = project_url;
+      } catch (error) {
+        console.error("Error importing project:", error);
+        alert(`Failed to import project:\n${error.message}`);
+      }
+    },
+    [createUrl, csrfToken],
+  );
+
+  return <ImportWizard onConfirm={onConfirm} />;
+}
+
+// --- Imperative mount/unmount interface used by the Stimulus controller ----
+
+/** @type {import("react-dom/client").Root|null} */
+let root = null;
+
+/**
+ * @param {Element} node
+ * @param {ImportConfig} config
+ * @returns {void}
+ */
+function render(node, config) {
+  root = ReactDOM.createRoot(node);
+  root.render(<ImportApp config={config} />);
+}
+
+/** @returns {void} */
+function destroy() {
+  root?.unmount();
+  root = null;
+}
+
+export { destroy, render };

--- a/app/javascript/controllers/react/import.jsx
+++ b/app/javascript/controllers/react/import.jsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from "react";
 import ReactDOM from "react-dom/client";
 import { ImportWizard } from "@pretextbook/import/react";
-import { serializeProjectToPlusPayload } from "@pretextbook/import";
+import { projectForImportMode, serializeProjectToPlusPayload } from "@pretextbook/import";
 import "@pretextbook/import/react.css";
 
 /** @typedef {import("@pretextbook/import").ImportedProjectSuccess} ImportedProjectSuccess */
+/** @typedef {import("@pretextbook/import").ImportMode} ImportMode */
 
 /**
  * @typedef {Object} ImportConfig
@@ -19,14 +20,24 @@ import "@pretextbook/import/react.css";
 function ImportApp({ config }) {
   const { createUrl, csrfToken } = config;
 
-  // serializeProjectToPlusPayload emits the Rails shape directly -- snake_case
-  // keys matching ProjectsController's permitted `divisions_attributes` /
-  // `assets_attributes`, with asset bytes base64-encoded -- so the payload goes
-  // straight over the same JSON API the editor uses, with nothing to map here.
+  // projectForImportMode picks the division pool matching the user's choice at
+  // the review step: the native LaTeX/Markdown pool when they keep the source
+  // format, the converted PreTeXt pool otherwise (and for PreTeXt input, which
+  // has no native projection).
+  //
+  // serializeProjectToPlusPayload then emits the Rails shape directly --
+  // snake_case keys matching ProjectsController's permitted
+  // `divisions_attributes` / `assets_attributes`, with asset bytes
+  // base64-encoded -- so the payload goes straight over the same JSON API the
+  // editor uses, with nothing to map here.
   const onConfirm = useCallback(
-    /** @param {ImportedProjectSuccess} result */
-    async (result) => {
+    /**
+     * @param {ImportedProjectSuccess} result
+     * @param {ImportMode} mode
+     */
+    async (result, mode) => {
       try {
+        const payload = serializeProjectToPlusPayload(projectForImportMode(result, mode));
         const res = await fetch(createUrl, {
           method: "POST",
           headers: {
@@ -34,7 +45,7 @@ function ImportApp({ config }) {
             Accept: "application/json",
             "X-CSRF-Token": csrfToken,
           },
-          body: JSON.stringify({ project: serializeProjectToPlusPayload(result.project) }),
+          body: JSON.stringify({ project: payload }),
         });
         if (!res.ok) {
           let message = `Import failed: ${res.status}`;

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,6 +15,13 @@ class Project < ApplicationRecord
 
   enum :document_type, { article: 0, book: 1, slideshow: 2 }, default: :article, suffix: true, validate: true
 
+  # Templates are curated projects the PreTeXt.Plus team flags (via the admin
+  # UI) as starting points; picking one duplicates it into the chooser's account.
+  # A template is otherwise an ordinary project for its owner: it still appears
+  # in their project list (badged, so they know edits affect what new users
+  # start from) and still counts against their quota.
+  scope :templates, -> { where(is_template: true) }
+
   default_scope { order(updated_at: :desc) }
 
   def root_division
@@ -69,6 +76,17 @@ class Project < ApplicationRecord
       new_asset.file.attach(asset.file.blob) if asset.file.attached?
     end
     duplicate
+  end
+
+  # Build a user's own project from this template: a deep copy (divisions,
+  # assets, docinfo) via full_dup, but stripped of its template identity and
+  # keeping the template's own title rather than "Copy of ...".
+  def instantiate_for(new_owner)
+    copy = full_dup(new_owner)
+    copy.title = title
+    copy.is_template = false
+    copy.template_description = nil
+    copy
   end
 
   def enqueue_html_source_job

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -31,6 +31,28 @@
     </div>
   </section>
 
+  <section class="mt-8 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 class="text-2xl font-semibold">Template</h2>
+    <p class="mt-1 text-sm text-gray-600">
+      Offer this project as a starting template on the new-project page. Its title
+      is shown as the template name; the description below appears in the picker.
+      The project stays in its owner's list, badged as a template.
+    </p>
+    <%= form_with model: @project, url: admin_project_path(@project), method: :patch, class: "mt-4 space-y-4" do |form| %>
+      <label class="flex items-center gap-2">
+        <%= form.check_box :is_template, class: "size-4 rounded border-gray-300" %>
+        <span class="text-sm font-medium text-gray-800">Offer as template</span>
+      </label>
+      <div>
+        <%= form.label :template_description, "Description", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.text_area :template_description, rows: 3,
+              placeholder: "What does this template get the user? (shown in the template picker)",
+              class: "w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+      </div>
+      <%= form.submit "Save template settings", class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium cursor-pointer" %>
+    <% end %>
+  </section>
+
   <section class="mt-8 grid gap-6 xl:grid-cols-2">
     <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
       <h2 class="text-2xl font-semibold">PreTeXt preview</h2>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -41,7 +41,7 @@
     <% if @projects.any? %>
       <% @projects.each do |project| %>
         <% updated_at_local = project.updated_at.localtime %>
-        <%= link_to project, class: "block rounded-xl bg-white p-4 m-3 ring-2 ring-gray-100 hover:ring-indigo-200 sm:p-6 lg:p-8", data: { turbo: false } do %>
+        <%= link_to project, class: "block rounded-xl p-4 m-3 ring-2 sm:p-6 lg:p-8 #{project.is_template? ? 'bg-amber-50 ring-amber-300 hover:ring-amber-400' : 'bg-white ring-gray-100 hover:ring-indigo-200'}", data: { turbo: false } do %>
           <span class="flex items-start sm:gap-8">
             <span class="hidden sm:grid sm:size-20 sm:shrink-0 sm:place-content-center" aria-hidden="true">
               <% if project.root_division&.latex_source_format? %>
@@ -68,9 +68,22 @@
                 </strong>
               <% end %>
 
+              <% if project.is_template? %>
+                <strong class="rounded-sm border border-amber-500 bg-amber-500 px-3 py-1.5 mx-3 text-[10px] font-medium text-white">
+                  Template
+                </strong>
+              <% end %>
+
               <h3 class="mt-4 text-lg font-medium sm:text-xl">
                 <%= project.title %>
               </h3>
+
+              <% if project.is_template? %>
+                <p class="mt-1 text-sm text-amber-800">
+                  ⚠ This project is offered as a template on the new-project page. Edit with care —
+                  your changes affect what new users start from.
+                </p>
+              <% end %>
 
               <p class="mt-1 text-sm text-gray-700">
                 Last updated:

--- a/app/views/projects/new.html.erb
+++ b/app/views/projects/new.html.erb
@@ -1,87 +1,201 @@
 <% content_for :title, "New Project" %>
 
-<div class="mx-auto w-full md:w-2/3 lg:w-1/2 px-4 pt-4 pb-12 md:px-0">
-    <% if @project.errors.any? %>
-      <div class="mb-6 rounded-md bg-red-50 border border-red-200 p-4">
-        <h2 class="font-semibold text-red-800 mb-2">Please fix the following errors:</h2>
-        <ul class="list-disc list-inside text-sm text-red-700">
-          <% @project.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-    <h1 class="font-bold text-3xl mb-2">New Project</h1>
-    <p class="text-gray-500 mb-8">Configure your project, then dive into the editor.</p>
+<%
+  # Small mapping from a division source_format to the badge shown for it, so
+  # both the template picker and the empty-document form read consistently with
+  # the projects index page.
+  format_badge = {
+    "pretext"  => [ "PreTeXt",               "border-indigo-500 bg-indigo-500" ],
+    "latex"    => [ "LaTeX-style PreTeXt",    "border-orange-500 bg-orange-500" ],
+    "markdown" => [ "Markdown-style PreTeXt", "border-purple-500 bg-purple-500" ]
+  }
+%>
 
-    <%= form_with model: @project, class: "space-y-8" do |form| %>
-      <div>
-        <label class="block text-sm font-semibold text-gray-700 mb-1" for="project_title">
-          Project name
-        </label>
-        <%= form.text_field :title,
-              placeholder: "New Project",
-              class: "w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
-        <p class="mt-1 text-xs text-gray-400">You can rename it later from the editor.</p>
+<div class="mx-auto w-full md:w-5/6 lg:w-4/5 px-4 pt-4 pb-12 md:px-0"
+     data-controller="new-project"
+     <%= 'data-open-dialog="empty"'.html_safe if @project.errors.any? %>>
+
+  <h1 class="font-bold text-3xl mb-2">New Project</h1>
+  <p class="text-gray-500 mb-8">Choose how you'd like to get started.</p>
+
+  <div class="grid gap-5 md:grid-cols-3">
+    <%# Card 1: empty document %>
+    <button type="button"
+            class="text-left block rounded-xl bg-white p-6 ring-2 ring-gray-100 hover:ring-indigo-300 transition cursor-pointer"
+            data-action="new-project#open" data-new-project-dialog-param="empty">
+      <div class="text-3xl mb-3" aria-hidden="true">📄</div>
+      <h2 class="font-semibold text-lg mb-1">New empty document</h2>
+      <p class="text-sm text-gray-600">Start from a bare-bones document in the markup style of your choice.</p>
+    </button>
+
+    <%# Card 2: from template %>
+    <button type="button"
+            class="text-left block rounded-xl bg-white p-6 ring-2 ring-gray-100 hover:ring-indigo-300 transition cursor-pointer"
+            data-action="new-project#open" data-new-project-dialog-param="template">
+      <div class="text-3xl mb-3" aria-hidden="true">🧩</div>
+      <h2 class="font-semibold text-lg mb-1">Start project from template</h2>
+      <p class="text-sm text-gray-600">Begin with a ready-made project curated by the PreTeXt.Plus team.</p>
+    </button>
+
+    <%# Card 3: import %>
+    <button type="button"
+            class="text-left block rounded-xl bg-white p-6 ring-2 ring-gray-100 hover:ring-indigo-300 transition cursor-pointer"
+            data-action="new-project#open" data-new-project-dialog-param="import">
+      <div class="text-3xl mb-3" aria-hidden="true">📥</div>
+      <h2 class="font-semibold text-lg mb-1">Import existing documents</h2>
+      <p class="text-sm text-gray-600">Bring in and convert an existing LaTeX, Markdown, or PreTeXt file or archive.</p>
+    </button>
+  </div>
+
+  <div class="mt-8">
+    <%= link_to "Cancel", projects_path,
+          class: "rounded-md px-5 py-2.5 bg-gray-100 hover:bg-gray-200 font-medium text-gray-700" %>
+  </div>
+
+  <%# ---- Dialog: New empty document ---------------------------------------- %>
+  <dialog data-new-project-target="dialog" data-dialog-name="empty"
+          class="rounded-xl p-0 m-auto w-[calc(100%-2rem)] max-w-2xl max-h-[85vh] overflow-y-auto backdrop:bg-black/40">
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-4">
+        <h2 class="font-bold text-2xl">New empty document</h2>
+        <button type="button" class="text-gray-400 hover:text-gray-700 text-2xl leading-none"
+                data-action="new-project#close" aria-label="Close">&times;</button>
       </div>
 
-      <%= form.fields_for :divisions do |fields| %>
-        <%= fields.hidden_field :is_root %>
-        <%= fields.hidden_field :ref %>
-        <div>
-          <p class="block text-sm font-semibold text-gray-700 mb-3">Markup style</p>
-          <% format_labels = [
-              [ "pretext",
-                "PreTeXt",
-                "Semantic XML markup language designed for academic writing with a focus on accessibility.",
-                "ring-indigo-100 hover:ring-indigo-200 has-[:checked]:border-indigo-600 has-[:checked]:bg-indigo-50",
-                true ],
-              [ "latex",
-                "LaTeX-style PreTeXt",
-                "A subset of the classic typesetting language compatible with PreTeXt.",
-                "ring-orange-100 hover:ring-orange-200 has-[:checked]:border-orange-500 has-[:checked]:bg-orange-50",
-                true ],
-              [ "markdown",
-                "Markdown-style PreTeXt",
-                "Flavor of the popular lightweight markup language compatible with PreTeXt.",
-                "ring-purple-100 hover:ring-purple-200 has-[:checked]:border-purple-500 has-[:checked]:bg-purple-50",
-                true ]
-            ] %>
-          <% format_labels.each do |value, title, description, colors, enabled| %>
-            <%= label_tag nil, 
-                class: enabled ?
-                  "block rounded-xl bg-white p-4 m-3 ring-2 cursor-pointer sm:p-6 lg:p-8 has-[:checked]:text-gray-900 transition-colors #{colors}" :
-                  "block rounded-xl bg-gray-100 text-gray-400 p-4 m-3 ring-2 ring-gray-200 cursor-not-allowed sm:p-6 lg:p-8",
-                disabled: !enabled do %>
-              <%= fields.radio_button :source_format, value, class: "sr-only" %>
-              <span class="flex items-start sm:gap-8">
-                <span class="hidden sm:grid sm:size-20 sm:shrink-0 sm:place-content-center" aria-hidden="true">
-                  <% if value == "latex" %>
-                    <%= image_tag "latex-pretext-logo.svg", alt: "PreTeXt logo", class: enabled ? nil : "opacity-30" %>
-                  <% elsif value == "markdown" %>
-                    <%= image_tag "markdown-pretext-logo.svg", alt: "PreTeXt logo", class: enabled ? nil : "opacity-30" %>
-                  <% else %>
-                    <%= image_tag "pretext-logo.svg", alt: "PreTeXt logo", class: enabled ? nil : "opacity-30" %>
-                  <% end %>
-                </span>
-                <span>
-                  <span class="flex items-center gap-2 mb-1">
-                    <span class="font-semibold"><%= title %><% unless enabled %> (coming soon!)<% end %></span>
-                    <span class="hidden has-sibling-checked:inline text-indigo-600 text-xs font-medium">✓ selected</span>
-                  </span>
-                  <span class="text-sm"><%= description %></span>
-                </span>
-              </span>
+      <% if @project.errors.any? %>
+        <div class="mb-6 rounded-md bg-red-50 border border-red-200 p-4">
+          <h3 class="font-semibold text-red-800 mb-2">Please fix the following errors:</h3>
+          <ul class="list-disc list-inside text-sm text-red-700">
+            <% @project.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
             <% end %>
-          <% end %>
+          </ul>
         </div>
       <% end %>
 
-      <div class="flex items-center gap-4 pb-4">
-        <%= form.submit "Create project",
-              class: "rounded-md px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium cursor-pointer" %>
-        <%= link_to "Cancel", projects_path,
-              class: "rounded-md px-5 py-2.5 bg-gray-100 hover:bg-gray-200 font-medium text-gray-700" %>
+      <%= form_with model: @project, class: "space-y-6" do |form| %>
+        <div>
+          <label class="block text-sm font-semibold text-gray-700 mb-1" for="project_title">
+            Project name
+          </label>
+          <%= form.text_field :title,
+                placeholder: "New Project",
+                class: "w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500" %>
+          <p class="mt-1 text-xs text-gray-400">You can rename it later from the editor.</p>
+        </div>
+
+        <%= form.fields_for :divisions do |fields| %>
+          <%= fields.hidden_field :is_root %>
+          <%= fields.hidden_field :ref %>
+          <div>
+            <p class="block text-sm font-semibold text-gray-700 mb-3">Markup style</p>
+            <% format_labels = [
+                [ "pretext",
+                  "PreTeXt",
+                  "Semantic XML markup language designed for academic writing with a focus on accessibility.",
+                  "ring-indigo-100 hover:ring-indigo-200 has-[:checked]:border-indigo-600 has-[:checked]:bg-indigo-50",
+                  true ],
+                [ "latex",
+                  "LaTeX-style PreTeXt",
+                  "A subset of the classic typesetting language compatible with PreTeXt.",
+                  "ring-orange-100 hover:ring-orange-200 has-[:checked]:border-orange-500 has-[:checked]:bg-orange-50",
+                  true ],
+                [ "markdown",
+                  "Markdown-style PreTeXt",
+                  "Flavor of the popular lightweight markup language compatible with PreTeXt.",
+                  "ring-purple-100 hover:ring-purple-200 has-[:checked]:border-purple-500 has-[:checked]:bg-purple-50",
+                  true ]
+              ] %>
+            <div class="grid gap-3 sm:grid-cols-3">
+              <% format_labels.each do |value, title, description, colors, enabled| %>
+                <%= label_tag nil,
+                    class: enabled ?
+                      "flex flex-col items-center text-center rounded-xl bg-white p-3 ring-2 cursor-pointer has-[:checked]:text-gray-900 transition-colors #{colors}" :
+                      "flex flex-col items-center text-center rounded-xl bg-gray-100 text-gray-400 p-3 ring-2 ring-gray-200 cursor-not-allowed",
+                    disabled: !enabled do %>
+                  <%= fields.radio_button :source_format, value, class: "sr-only" %>
+                  <span class="grid size-10 shrink-0 place-content-center mb-2" aria-hidden="true">
+                    <% if value == "latex" %>
+                      <%= image_tag "latex-pretext-logo.svg", alt: "PreTeXt logo", class: enabled ? nil : "opacity-30" %>
+                    <% elsif value == "markdown" %>
+                      <%= image_tag "markdown-pretext-logo.svg", alt: "PreTeXt logo", class: enabled ? nil : "opacity-30" %>
+                    <% else %>
+                      <%= image_tag "pretext-logo.svg", alt: "PreTeXt logo", class: enabled ? nil : "opacity-30" %>
+                    <% end %>
+                  </span>
+                  <span class="text-sm font-semibold leading-tight"><%= title %><% unless enabled %> (coming soon!)<% end %></span>
+                  <span class="hidden has-sibling-checked:inline text-indigo-600 text-xs font-medium mt-0.5">✓ selected</span>
+                  <span class="mt-1 text-xs text-gray-500 leading-snug"><%= description %></span>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="flex items-center gap-4 pt-2">
+          <%= form.submit "Create project",
+                class: "rounded-md px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium cursor-pointer" %>
+          <button type="button" class="rounded-md px-5 py-2.5 bg-gray-100 hover:bg-gray-200 font-medium text-gray-700"
+                  data-action="new-project#close">Cancel</button>
+        </div>
+      <% end %>
+    </div>
+  </dialog>
+
+  <%# ---- Dialog: Start project from template ------------------------------- %>
+  <dialog data-new-project-target="dialog" data-dialog-name="template"
+          class="rounded-xl p-0 m-auto w-[calc(100%-2rem)] max-w-2xl max-h-[85vh] overflow-y-auto backdrop:bg-black/40">
+    <div class="p-6">
+      <div class="flex items-start justify-between mb-4">
+        <h2 class="font-bold text-2xl">Start project from template</h2>
+        <button type="button" class="text-gray-400 hover:text-gray-700 text-2xl leading-none"
+                data-action="new-project#close" aria-label="Close">&times;</button>
       </div>
-    <% end %>
+
+      <% if @templates.any? %>
+        <p class="text-sm text-gray-500 mb-4">Pick a template to copy into your account. You can edit everything afterwards.</p>
+        <ul class="space-y-3">
+          <% @templates.each do |template| %>
+            <% label, badge_classes = format_badge[template.root_division&.source_format || "pretext"] %>
+            <li class="rounded-xl ring-2 ring-gray-100 p-4">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <div class="flex items-center gap-2 mb-1">
+                    <strong class="rounded-sm border <%= badge_classes %> px-2.5 py-1 text-[10px] font-medium text-white">
+                      <%= label %>
+                    </strong>
+                    <h3 class="text-lg font-medium"><%= template.title %></h3>
+                  </div>
+                  <% if template.template_description.present? %>
+                    <p class="text-sm text-gray-600"><%= template.template_description %></p>
+                  <% end %>
+                </div>
+                <%= button_to "Use this template", create_from_template_projects_path(template_id: template.id),
+                      class: "shrink-0 rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium cursor-pointer" %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-gray-600 py-6 text-center">No templates are available yet. Check back soon!</p>
+      <% end %>
+    </div>
+  </dialog>
+
+  <%# ---- Dialog: Import existing documents --------------------------------- %>
+  <dialog data-new-project-target="dialog" data-dialog-name="import"
+          class="rounded-xl p-0 m-auto w-[calc(100%-2rem)] max-w-3xl max-h-[85vh] overflow-y-auto backdrop:bg-black/40">
+    <div class="p-6"
+         data-controller="import"
+         data-import-create-url-value="<%= create_from_import_projects_path %>">
+      <div class="flex items-start justify-between mb-4">
+        <h2 class="font-bold text-2xl">Import existing documents</h2>
+        <button type="button" class="text-gray-400 hover:text-gray-700 text-2xl leading-none"
+                data-action="new-project#close" aria-label="Close">&times;</button>
+      </div>
+      <div data-import-target="root">
+        <p class="text-gray-500">Loading importer…</p>
+      </div>
+    </div>
+  </dialog>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
         post :reset_password
       end
     end
-    resources :projects, only: %i[show]
+    resources :projects, only: %i[show update]
     resources :terms, only: %i[new create]
     resources :announcements do
       member do
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
       end
     end
     collection do
+      post "from_template/:template_id" => "projects#create_from_template", as: "create_from_template"
+      post "import" => "projects#create_from_import", as: "create_from_import"
       post "feedback" => "projects#feedback", as: "feedback"
       get "lunr-pretext-search-index.js", to: redirect("/ptx-search.js")
       get "*_/lunr-pretext-search-index.js", to: redirect("/ptx-search.js")

--- a/db/migrate/20260722120000_add_template_fields_to_projects.rb
+++ b/db/migrate/20260722120000_add_template_fields_to_projects.rb
@@ -1,0 +1,7 @@
+class AddTemplateFieldsToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :is_template, :boolean, default: false, null: false
+    add_column :projects, :template_description, :text
+    add_index :projects, :is_template
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_11_111301) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -200,11 +200,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_111301) do
     t.text "docinfo"
     t.integer "document_type", default: 0, null: false
     t.text "html_source"
+    t.boolean "is_template", default: false, null: false
     t.text "pretext_source"
+    t.text "template_description"
     t.string "title"
     t.datetime "updated_at", null: false
     t.boolean "use_common_docinfo", default: false, null: false
     t.uuid "user_id", null: false
+    t.index ["is_template"], name: "index_projects_on_is_template"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.20",
+        "@pretextbook/import": "^0.2.0",
         "@pretextbook/web-editor": "^0.16.0",
         "@tanstack/react-query": "^5.101.0",
         "react": "^19.2.0",
@@ -686,6 +687,24 @@
       },
       "peerDependencies": {
         "unified": ">=11"
+      }
+    },
+    "node_modules/@pretextbook/import": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/import/-/import-0.2.0.tgz",
+      "integrity": "sha512-hhTzPvQ4dyUe5mqAs8hRDceXzB7LsdISMUT96u0ZonrfuSM3pDN8J7V+MjhZvyJAjixn6m+57vk5GTUYuVdfmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pretextbook/format": "*",
+        "@pretextbook/latex-pretext": "*",
+        "@pretextbook/remark-pretext": "*",
+        "@tailwindcss/vite": "^4.0.0",
+        "jszip": "^3.10.1",
+        "tailwindcss": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@pretextbook/latex-pretext": {
@@ -2757,6 +2776,12 @@
       "integrity": "sha512-OXZrivIHbMqFVDNF1/wBI3SBWQCPPesGoeBJ7Cev0KHnnxN9Oei2I8OXfOv5ROzliCXDYA5x4RWtDuByFDY2vQ==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2956,6 +2981,18 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -3041,6 +3078,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -3048,6 +3091,18 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/katex": {
@@ -3064,6 +3119,15 @@
       },
       "bin": {
         "katex": "cli.js"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3943,6 +4007,12 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4045,6 +4115,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.1",
@@ -4216,6 +4292,21 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/remark-directive": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
@@ -4288,10 +4379,22 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/simple-swizzle": {
@@ -4317,6 +4420,15 @@
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4512,7 +4624,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.20",
-        "@pretextbook/import": "^0.2.0",
+        "@pretextbook/import": "^0.3.0",
         "@pretextbook/web-editor": "^0.16.0",
         "@tanstack/react-query": "^5.101.0",
         "react": "^19.2.0",
@@ -690,9 +690,9 @@
       }
     },
     "node_modules/@pretextbook/import": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/import/-/import-0.2.0.tgz",
-      "integrity": "sha512-hhTzPvQ4dyUe5mqAs8hRDceXzB7LsdISMUT96u0ZonrfuSM3pDN8J7V+MjhZvyJAjixn6m+57vk5GTUYuVdfmQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/import/-/import-0.3.0.tgz",
+      "integrity": "sha512-8me6cw+8JVmDqBQWlaOXpChyxcvRuzzo8DuMgakg4KfQiO3R4mQFrhAJi54kpE0k+fPmHiSJJQ6Nm+Mgab8WLQ==",
       "license": "MIT",
       "dependencies": {
         "@pretextbook/format": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.20",
         "@pretextbook/import": "^0.3.0",
-        "@pretextbook/web-editor": "^0.17.0",
+        "@pretextbook/web-editor": "^0.17.1",
         "@tanstack/react-query": "^5.101.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@pretextbook/completions": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@pretextbook/completions/-/completions-0.0.3.tgz",
-      "integrity": "sha512-wJt3quh0j2sCFpDxB4KYWrcu5QKrnOkSkbf9cg7UPimVMC0SHdGpXx7T32UhQF52MnRZPyq6ZgeIqYbPYwfWTg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/completions/-/completions-0.1.0.tgz",
+      "integrity": "sha512-UOqctIUNraXH5dehNV0vxN6LFNhxq0gkqcqb0z+HG+0n8LaLpOxd6zecPTs5pmsq6WtcDysUhCpgliGbOoj+ZQ==",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver": "^9.0.1"
@@ -708,12 +708,12 @@
       }
     },
     "node_modules/@pretextbook/latex-pretext": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@pretextbook/latex-pretext/-/latex-pretext-0.0.13.tgz",
-      "integrity": "sha512-XztKiijrmilPeWu10h3gGRBe1B7YzUL7SeTLR3FptQhz3kZTeY0sf4PkNIQ1uXeOtruMaThep8dtbnH/pqxLzg==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@pretextbook/latex-pretext/-/latex-pretext-0.0.14.tgz",
+      "integrity": "sha512-+1qDEbii4TcFEBE52/9CqhemkPyEeACXIXgAX4+TVt49N2FPlEtzr2mdSaWlL/gVqR4jtq/EZPz7JVc29l1yIg==",
       "license": "MIT",
       "dependencies": {
-        "@pretextbook/unified-latex-to-pretext": "^0.0.4",
+        "@pretextbook/unified-latex-to-pretext": "^0.0.5",
         "@unified-latex/unified-latex-types": "^1.8.4",
         "@unified-latex/unified-latex-util-parse": "^1.8.4",
         "tslib": "^2.3.0"
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@pretextbook/pretext-html": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/pretext-html/-/pretext-html-0.3.0.tgz",
-      "integrity": "sha512-+7IBcvQWJ8znuF2YXUuTuXrhHFegyHecys4xdRp34BE4gq7DHflXk+ndysEILNQdutIxA+9YMxfsGqSx5lkKOw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/pretext-html/-/pretext-html-0.4.0.tgz",
+      "integrity": "sha512-g+WyypXCQ+6vsO0hJj5imLxCF9OkhQVICNA+WvrkPSrL8TO3NkxNVxFF0JjqfwvWuGzoaqx6XgFHdBRPssnqwA==",
       "license": "MIT",
       "dependencies": {
         "@pretextbook/libxslt-wasm": "^0.1.1",
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@pretextbook/unified-latex-to-pretext": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@pretextbook/unified-latex-to-pretext/-/unified-latex-to-pretext-0.0.4.tgz",
-      "integrity": "sha512-MoE1uLv5Sp7+60FfNhPdR9ZgoFQhgeVl8OkxTHpZ6lVa1nzrV1TALvj5tTRq8CV/zVZ+fdPdbFAGuIFV24wE/g==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@pretextbook/unified-latex-to-pretext/-/unified-latex-to-pretext-0.0.5.tgz",
+      "integrity": "sha512-MjyszZdC5xAyG9DOzZfSbfUR1mZYH1mTs5+/Z5UBlBcbC5MzFWWHTH0TdjeL07HIWkUxvlC0BnzsAoX5IgHVXg==",
       "license": "MIT",
       "dependencies": {
         "@unified-latex/unified-latex": "^1.8.4",
@@ -891,58 +891,43 @@
       }
     },
     "node_modules/@pretextbook/visual-editor": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@pretextbook/visual-editor/-/visual-editor-0.0.6.tgz",
-      "integrity": "sha512-g+YRMrm2oAdxrXFeiiUZpCKUxHn/bbMUKxY/Yz9x061Y8dnN+0SfBVAdGC/lGEfqVpPTWNmFeZBW0PXssnR+nQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/visual-editor/-/visual-editor-0.1.0.tgz",
+      "integrity": "sha512-Uu+WS5/aS2s49k3AGAAapCXpmC3HY/MC7TxBYhq5LliOb6A8vAjqhjAlbbIITdpZs3iSyxDtIFbzER/FTotQJg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
-        "@pretextbook/format": "0.2.0",
-        "@tiptap/extension-code-block": "^3.14.0",
-        "@tiptap/extension-list": "^3.14.0",
-        "@tiptap/extensions": "^3.14.0",
-        "@tiptap/pm": "^3.14.0",
-        "@tiptap/react": "^3.14.0",
-        "katex": "^0.16.37"
+        "@pretextbook/format": "0.3.0",
+        "@tiptap/extension-code-block": "^3.28.0",
+        "@tiptap/extension-list": "^3.28.0",
+        "@tiptap/extensions": "^3.28.0",
+        "@tiptap/pm": "^3.28.0",
+        "@tiptap/react": "^3.28.0",
+        "katex": "^0.18.1"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@pretextbook/visual-editor/node_modules/@pretextbook/format": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/format/-/format-0.2.0.tgz",
-      "integrity": "sha512-O5uAw6gBty19BxoChTSMNoDGzmD41Mj6mqbYLjWOHe5HrIBALrJiPX38aGNVhtsD8nfgPdE4Y+/Cs6hN32yuvA==",
-      "license": "MIT",
-      "dependencies": {
-        "xast-util-from-xml": "^4.0.0"
-      },
-      "bin": {
-        "pretext-format": "cli.cjs"
-      },
-      "peerDependencies": {
-        "unified": ">=11"
-      }
-    },
     "node_modules/@pretextbook/web-editor": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/web-editor/-/web-editor-0.17.0.tgz",
-      "integrity": "sha512-+2pl36h1/ozcumTTtU4FniATAEzX5DFx0OUjqnYXEZpM1AO2njsOduzXZLHS7H769O6eLAQEjLM4LkPbJ7clkA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@pretextbook/web-editor/-/web-editor-0.17.1.tgz",
+      "integrity": "sha512-nsZhrrK6flAwwSD4AQsYPGXseOaC7pPsnIu9VxsUnr+RDO8Q8fa1z7E5JsxjYP/KuI+4AIhnOip6L7zO0Uhd6A==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@monaco-editor/react": "^4.8.0-rc.3",
-        "@pretextbook/completions": "^0.0.3",
-        "@pretextbook/format": "^0.2.0",
-        "@pretextbook/latex-pretext": "^0.0.12",
+        "@pretextbook/completions": "^0.1.0",
+        "@pretextbook/format": "^0.3.0",
+        "@pretextbook/latex-pretext": "^0.0.14",
         "@pretextbook/latex-style-pretext": "^0.0.1",
         "@pretextbook/markdown-style-pretext": "^0.0.1",
-        "@pretextbook/pretext-html": "^0.3.0",
-        "@pretextbook/remark-pretext": "^0.0.10",
-        "@pretextbook/visual-editor": "^0.0.6",
-        "@tailwindcss/vite": "^4.1.18",
+        "@pretextbook/pretext-html": "^0.4.0",
+        "@pretextbook/remark-pretext": "^0.0.11",
+        "@pretextbook/visual-editor": "^0.1.0",
+        "@tailwindcss/vite": "^4.3.3",
         "constrained-editor-plugin": "^1.4.0",
         "react-resizable-panels": "^4.12.2",
         "tailwindcss": "^4.3.3",
@@ -952,59 +937,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/format": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@pretextbook/format/-/format-0.2.1.tgz",
-      "integrity": "sha512-JYHrqjp/3TmxqTLE3/fVMQ2UIBCsCVERUlUS3ulh+CmGrRYN2MukfTbrZBwVdAwyg9mZpmfeh0WEs8bAEVLrGw==",
-      "license": "MIT",
-      "dependencies": {
-        "xast-util-from-xml": "^4.0.0"
-      },
-      "bin": {
-        "pretext-format": "cli.cjs"
-      },
-      "peerDependencies": {
-        "unified": ">=11"
-      }
-    },
-    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/latex-pretext": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@pretextbook/latex-pretext/-/latex-pretext-0.0.12.tgz",
-      "integrity": "sha512-O5hoSq+kGFqpzwyHJarvrCKPZ2LlxRMNWH10typpARjNehulDLF2QfbFtn5bjvybPbTfOxu0EaBP+UhCsDQPgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@pretextbook/unified-latex-to-pretext": "^0.0.4",
-        "@unified-latex/unified-latex-types": "^1.8.4",
-        "@unified-latex/unified-latex-util-parse": "^1.8.4",
-        "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/ptxast": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@pretextbook/ptxast/-/ptxast-0.0.7.tgz",
-      "integrity": "sha512-1F8OQxj7K9LFuo77ls37SOlJ76PWUp9p/a0xqRC7VArMSu4BQ/ZFP/xwVY0hqb/moXBQNlH1nIaUCSF+VXoEzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "@types/xast": "^2.0.4"
-      }
-    },
-    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/remark-pretext": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@pretextbook/remark-pretext/-/remark-pretext-0.0.10.tgz",
-      "integrity": "sha512-bSWR3WP7+OCr5BPPohb/o1ht51OIXuDhwDffJLSe2NPLatdEKmBqSsxHbeM4TtpnshbHXjPP68sG0khz/vhYTA==",
-      "license": "MIT",
-      "dependencies": {
-        "@pretextbook/ptxast": "^0.0.7",
-        "@types/mdast": "^4.0.0",
-        "mdast-util-directive": "^3.0.0",
-        "remark-directive": "^4.0.0",
-        "remark-parse": "^11.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit": "^5.0.0",
-        "xast-util-to-xml": "^4.0.0"
       }
     },
     "node_modules/@rails/actioncable": {
@@ -3195,9 +3127,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
+      "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.20",
         "@pretextbook/import": "^0.3.0",
-        "@pretextbook/web-editor": "^0.16.0",
+        "@pretextbook/web-editor": "^0.17.0",
         "@tanstack/react-query": "^5.101.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@pretextbook/completions": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/completions/-/completions-0.1.0.tgz",
-      "integrity": "sha512-UOqctIUNraXH5dehNV0vxN6LFNhxq0gkqcqb0z+HG+0n8LaLpOxd6zecPTs5pmsq6WtcDysUhCpgliGbOoj+ZQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@pretextbook/completions/-/completions-0.0.3.tgz",
+      "integrity": "sha512-wJt3quh0j2sCFpDxB4KYWrcu5QKrnOkSkbf9cg7UPimVMC0SHdGpXx7T32UhQF52MnRZPyq6ZgeIqYbPYwfWTg==",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver": "^9.0.1"
@@ -719,6 +719,15 @@
         "tslib": "^2.3.0"
       }
     },
+    "node_modules/@pretextbook/latex-style-pretext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@pretextbook/latex-style-pretext/-/latex-style-pretext-0.0.1.tgz",
+      "integrity": "sha512-Fb3q1BDQke41WJXifINPv49kSIe0ODCSwCsChq5fpuc+dZXAaCdea0Vvlxf69pYTdN0/DJlaDzXBwdgB9dQc1w==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-types": "^3.17.5"
+      }
+    },
     "node_modules/@pretextbook/libxslt-wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pretextbook/libxslt-wasm/-/libxslt-wasm-0.1.1.tgz",
@@ -726,6 +735,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=19.2.0"
+      }
+    },
+    "node_modules/@pretextbook/markdown-style-pretext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@pretextbook/markdown-style-pretext/-/markdown-style-pretext-0.0.1.tgz",
+      "integrity": "sha512-m/0fZ9f8HwC3ELCQgfVsRnlfO4pbRMhxK6rfK2W048FHoEGhg+OemuuORKaunMdcqm8hy4qAQLy8pZ1WdWcgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pretextbook/latex-style-pretext": "^0.0.1",
+        "vscode-languageserver-types": "^3.17.5"
       }
     },
     "node_modules/@pretextbook/pretext-html": {
@@ -872,41 +891,58 @@
       }
     },
     "node_modules/@pretextbook/visual-editor": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/visual-editor/-/visual-editor-0.1.0.tgz",
-      "integrity": "sha512-Uu+WS5/aS2s49k3AGAAapCXpmC3HY/MC7TxBYhq5LliOb6A8vAjqhjAlbbIITdpZs3iSyxDtIFbzER/FTotQJg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@pretextbook/visual-editor/-/visual-editor-0.0.6.tgz",
+      "integrity": "sha512-g+YRMrm2oAdxrXFeiiUZpCKUxHn/bbMUKxY/Yz9x061Y8dnN+0SfBVAdGC/lGEfqVpPTWNmFeZBW0PXssnR+nQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
-        "@pretextbook/format": "0.3.0",
-        "@tiptap/extension-code-block": "^3.28.0",
-        "@tiptap/extension-list": "^3.28.0",
-        "@tiptap/extensions": "^3.28.0",
-        "@tiptap/pm": "^3.28.0",
-        "@tiptap/react": "^3.28.0",
-        "katex": "^0.18.1"
+        "@pretextbook/format": "0.2.0",
+        "@tiptap/extension-code-block": "^3.14.0",
+        "@tiptap/extension-list": "^3.14.0",
+        "@tiptap/extensions": "^3.14.0",
+        "@tiptap/pm": "^3.14.0",
+        "@tiptap/react": "^3.14.0",
+        "katex": "^0.16.37"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@pretextbook/visual-editor/node_modules/@pretextbook/format": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/format/-/format-0.2.0.tgz",
+      "integrity": "sha512-O5uAw6gBty19BxoChTSMNoDGzmD41Mj6mqbYLjWOHe5HrIBALrJiPX38aGNVhtsD8nfgPdE4Y+/Cs6hN32yuvA==",
+      "license": "MIT",
+      "dependencies": {
+        "xast-util-from-xml": "^4.0.0"
+      },
+      "bin": {
+        "pretext-format": "cli.cjs"
+      },
+      "peerDependencies": {
+        "unified": ">=11"
+      }
+    },
     "node_modules/@pretextbook/web-editor": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@pretextbook/web-editor/-/web-editor-0.16.0.tgz",
-      "integrity": "sha512-zsgZj0lJz5HdGcsa+MTdNSVI8IEzSnCWjk7mqpTZjc2h9yIYTVPKcyN0HkZBczjlysOwFWZj43jCtll2Pb9U6g==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@pretextbook/web-editor/-/web-editor-0.17.0.tgz",
+      "integrity": "sha512-+2pl36h1/ozcumTTtU4FniATAEzX5DFx0OUjqnYXEZpM1AO2njsOduzXZLHS7H769O6eLAQEjLM4LkPbJ7clkA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@monaco-editor/react": "^4.8.0-rc.3",
-        "@pretextbook/completions": "^0.1.0",
-        "@pretextbook/format": "^0.3.0",
-        "@pretextbook/latex-pretext": "^0.0.13",
+        "@pretextbook/completions": "^0.0.3",
+        "@pretextbook/format": "^0.2.0",
+        "@pretextbook/latex-pretext": "^0.0.12",
+        "@pretextbook/latex-style-pretext": "^0.0.1",
+        "@pretextbook/markdown-style-pretext": "^0.0.1",
         "@pretextbook/pretext-html": "^0.3.0",
-        "@pretextbook/remark-pretext": "^0.0.11",
-        "@pretextbook/visual-editor": "^0.1.0",
-        "@tailwindcss/vite": "^4.3.3",
+        "@pretextbook/remark-pretext": "^0.0.10",
+        "@pretextbook/visual-editor": "^0.0.6",
+        "@tailwindcss/vite": "^4.1.18",
         "constrained-editor-plugin": "^1.4.0",
         "react-resizable-panels": "^4.12.2",
         "tailwindcss": "^4.3.3",
@@ -916,6 +952,59 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/format": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@pretextbook/format/-/format-0.2.1.tgz",
+      "integrity": "sha512-JYHrqjp/3TmxqTLE3/fVMQ2UIBCsCVERUlUS3ulh+CmGrRYN2MukfTbrZBwVdAwyg9mZpmfeh0WEs8bAEVLrGw==",
+      "license": "MIT",
+      "dependencies": {
+        "xast-util-from-xml": "^4.0.0"
+      },
+      "bin": {
+        "pretext-format": "cli.cjs"
+      },
+      "peerDependencies": {
+        "unified": ">=11"
+      }
+    },
+    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/latex-pretext": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@pretextbook/latex-pretext/-/latex-pretext-0.0.12.tgz",
+      "integrity": "sha512-O5hoSq+kGFqpzwyHJarvrCKPZ2LlxRMNWH10typpARjNehulDLF2QfbFtn5bjvybPbTfOxu0EaBP+UhCsDQPgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@pretextbook/unified-latex-to-pretext": "^0.0.4",
+        "@unified-latex/unified-latex-types": "^1.8.4",
+        "@unified-latex/unified-latex-util-parse": "^1.8.4",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/ptxast": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pretextbook/ptxast/-/ptxast-0.0.7.tgz",
+      "integrity": "sha512-1F8OQxj7K9LFuo77ls37SOlJ76PWUp9p/a0xqRC7VArMSu4BQ/ZFP/xwVY0hqb/moXBQNlH1nIaUCSF+VXoEzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "@types/xast": "^2.0.4"
+      }
+    },
+    "node_modules/@pretextbook/web-editor/node_modules/@pretextbook/remark-pretext": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@pretextbook/remark-pretext/-/remark-pretext-0.0.10.tgz",
+      "integrity": "sha512-bSWR3WP7+OCr5BPPohb/o1ht51OIXuDhwDffJLSe2NPLatdEKmBqSsxHbeM4TtpnshbHXjPP68sG0khz/vhYTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pretextbook/ptxast": "^0.0.7",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "remark-directive": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "xast-util-to-xml": "^4.0.0"
       }
     },
     "node_modules/@rails/actioncable": {
@@ -1494,9 +1583,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.28.0.tgz",
-      "integrity": "sha512-gUuD5WAYfbDxNSSJya/emh2KSzXZXLUYKW4fEnc1AQ5FE2twzh4LJ9UlKFIawigrUCAksWI5Fy1hRbv+5m4ZdQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.0.tgz",
+      "integrity": "sha512-A/lrhKpOYtl0V5pmPS00Zps8pgBe1qDOoD9fzsumDSZ3HP8W398C959Jgru75PNFokAya9COPD3iaKP3NWF25g==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -1504,13 +1593,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "3.28.0"
+        "@tiptap/pm": "3.29.0"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.28.0.tgz",
-      "integrity": "sha512-7AUNoHj2K4XLKCgW4uspeD/ENejPu2BeHvLTsiOoIO+XXDNSi2j0bbaIS8f2s/qnFirscwp/sbznp1qph/76qg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.0.tgz",
+      "integrity": "sha512-aBNI8ebX76ObderRmu/PJ9Q2AGVEuhpg0TBvv2SNbHtmU5kNUMHQI8HxrxKFblJwETAmG6EJ3Ed/5jRxpJmrsg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1521,28 +1610,28 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.28.0",
-        "@tiptap/pm": "3.28.0"
+        "@tiptap/core": "3.29.0",
+        "@tiptap/pm": "3.29.0"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.28.0.tgz",
-      "integrity": "sha512-bHITDzT0umTLh+SiEVQzIXkCMt/TzbPM1+HQy9ZxgQDHAJj/vdmfNAnP3RCOrz4lETXyhNQ2b6kxeu3lWckxyA==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.29.0.tgz",
+      "integrity": "sha512-nKm1YSEiPVosjm4qeg6m+6SAKq82rKukAzE/g3M5eVs2OgEb4QIKQvQOmJ+zgGAnpb9Q/JIvcKsGGU1rn9Vnyw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.28.0",
-        "@tiptap/pm": "3.28.0"
+        "@tiptap/core": "3.29.0",
+        "@tiptap/pm": "3.29.0"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.28.0.tgz",
-      "integrity": "sha512-59SECvJq3pQfeJBuydEdhQqrpl0oDlk8N1Ovs1Si3/fJa6rEQAJB2zIvcpBHky9Z+5JodI2eueDnv8eimiyGbg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.0.tgz",
+      "integrity": "sha512-/rFlN6T70HuT34kFvftKm56UX0IPff7vlII7Sqgs7DprKVYkItiU3lM7+AoeDRzCsWMg4z1yNHj70BPx7+EJ6Q==",
       "license": "MIT",
       "optional": true,
       "funding": {
@@ -1551,42 +1640,42 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.28.0",
-        "@tiptap/pm": "3.28.0"
+        "@tiptap/core": "3.29.0",
+        "@tiptap/pm": "3.29.0"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.28.0.tgz",
-      "integrity": "sha512-zQ66i5DuhVOndmZ0d7H475Y5Yb+BMx+zfCjFkCzEc6WVef5MumtxBVTkGLQ0ibxUaD71s4QQZbjHWagpaTg0eQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.29.0.tgz",
+      "integrity": "sha512-k0B/+nIkn4VvHSQ0kP+AzzAmgeOVxKMAdqG4a6qwxp/lR12aJGHlOP92KCjXV2RNPtuwDksJ1RIXrgxdf9WmJg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.28.0",
-        "@tiptap/pm": "3.28.0"
+        "@tiptap/core": "3.29.0",
+        "@tiptap/pm": "3.29.0"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.28.0.tgz",
-      "integrity": "sha512-DJT1khCK+O/pT1gQlAnoKAx6zwDkgv7GtnhSfkqm1/4KHC3x+SSJnBIgBl9oGHymA+DxWbW1EULU4V3d/kT2uQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.0.tgz",
+      "integrity": "sha512-ltlrm8dDHIgeNj3cOLEdLFMPPVy3TYvWA8ftrrJ44C/L01MBmgFB1f/vkPFYYnAasb2BYyVG6HxAGcTQHo5jHw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.28.0",
-        "@tiptap/pm": "3.28.0"
+        "@tiptap/core": "3.29.0",
+        "@tiptap/pm": "3.29.0"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.28.0.tgz",
-      "integrity": "sha512-ALcpwZMUdat9gjJKlpscpoqXStoLhU246LPEVBDvJdIsoUKvUu3MrzfXik2Y8mtSGfhjtm9O2TRkWxQiFVMwsQ==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.0.tgz",
+      "integrity": "sha512-4rr3HiZ8kbSNINuWXqKQJLv9fFMypCBN5gOwxoU+D4lEYVblkoM60fA1SlrI2BZVlZQmw2U38XKl5XMtUr55XQ==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.4.1",
@@ -1596,7 +1685,7 @@
         "prosemirror-history": "^1.5.0",
         "prosemirror-inputrules": "^1.5.1",
         "prosemirror-keymap": "^1.2.3",
-        "prosemirror-model": "^1.25.9",
+        "prosemirror-model": "^1.25.11",
         "prosemirror-schema-list": "^1.5.1",
         "prosemirror-state": "^1.4.4",
         "prosemirror-tables": "^1.8.5",
@@ -1609,9 +1698,9 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.28.0.tgz",
-      "integrity": "sha512-BxzSAqaDEldQ97K/v6+GizU1/Dxx9VWkRh7PLQql6bXlAMiz6T1G3dGt25vvv1hQ1FoMt5ExWY5NkrPmR8G8ew==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.29.0.tgz",
+      "integrity": "sha512-HmZf9q5/HXg5M2t09WGEbk16vEBDUGPlkF3eXcQh6yG6PkzMZHq1SP+uA8lWku5H/Ggfmv4XKjI6dEQa5V8bwA==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -1623,12 +1712,12 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.28.0",
-        "@tiptap/extension-floating-menu": "^3.28.0"
+        "@tiptap/extension-bubble-menu": "^3.29.0",
+        "@tiptap/extension-floating-menu": "^3.29.0"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.28.0",
-        "@tiptap/pm": "3.28.0",
+        "@tiptap/core": "3.29.0",
+        "@tiptap/pm": "3.29.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -3106,9 +3195,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
-      "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -4251,9 +4340,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.1.tgz",
-      "integrity": "sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==",
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.25.8",
@@ -4777,10 +4866,16 @@
         "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-types": {
+    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
+    "@pretextbook/import": "^0.2.0",
     "@pretextbook/web-editor": "^0.16.0",
     "@tanstack/react-query": "^5.101.0",
     "react": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
-    "@pretextbook/import": "^0.2.0",
+    "@pretextbook/import": "^0.3.0",
     "@pretextbook/web-editor": "^0.16.0",
     "@tanstack/react-query": "^5.101.0",
     "react": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
     "@pretextbook/import": "^0.3.0",
-    "@pretextbook/web-editor": "^0.16.0",
+    "@pretextbook/web-editor": "^0.17.0",
     "@tanstack/react-query": "^5.101.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
     "@pretextbook/import": "^0.3.0",
-    "@pretextbook/web-editor": "^0.17.0",
+    "@pretextbook/web-editor": "^0.17.1",
     "@tanstack/react-query": "^5.101.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/test/controllers/admin/projects_controller_test.rb
+++ b/test/controllers/admin/projects_controller_test.rb
@@ -26,4 +26,26 @@ class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Rendered share view"
     assert_includes response.body, "Read-only support view"
   end
+
+  test "admin can flag a project as a template with a description" do
+    sign_in @admin
+
+    patch admin_project_path(@project), params: {
+      project: { is_template: "1", template_description: "A great starter" }
+    }
+
+    assert_redirected_to admin_project_path(@project)
+    @project.reload
+    assert @project.is_template?
+    assert_equal "A great starter", @project.template_description
+  end
+
+  test "non-admin cannot update template settings" do
+    sign_in @non_admin
+
+    patch admin_project_path(@project), params: { project: { is_template: "1" } }
+
+    assert_redirected_to projects_path
+    assert_not @project.reload.is_template?
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -622,6 +622,41 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_equal edit_project_path(project), response.parsed_body["project_url"]
   end
 
+  test "create_from_import handles a multi-division book payload" do
+    # Shape produced by @pretextbook/import for a LaTeX book: a root division
+    # holding <plus:chapter ref="..."/> placeholders plus one row per chapter.
+    assert_difference("Project.count", 1) do
+      post create_from_import_projects_url,
+        params: {
+          project: {
+            title: "A Real Book",
+            docinfo: "",
+            document_type: "book",
+            divisions_attributes: [
+              { ref: "document", source_format: "pretext", is_root: true,
+                source: %(<book xml:id="document"><title>A Real Book</title><plus:chapter ref="ch-01"/><plus:chapter ref="ch-02"/></book>) },
+              { ref: "ch-01", source_format: "pretext", is_root: false,
+                source: %(<chapter xml:id="ch-01"><title>Alpha</title></chapter>) },
+              { ref: "ch-02", source_format: "pretext", is_root: false,
+                source: %(<chapter xml:id="ch-02"><title>Beta</title></chapter>) }
+            ],
+            assets_attributes: []
+          }
+        },
+        as: :json
+    end
+
+    assert_response :created
+    project = Project.find_by!(title: "A Real Book", user: @user)
+    assert project.book_document_type?
+    assert_equal 3, project.divisions.count
+    assert_equal 1, project.divisions.where(is_root: true).count
+    assert_equal "document", project.root_division.ref
+    assert_equal %w[ch-01 ch-02], project.divisions.where(is_root: false).order(:ref).pluck(:ref)
+    # An empty docinfo from the importer falls back to the app default.
+    assert_equal Project.default_docinfo, project.docinfo
+  end
+
   test "create_from_import requires authentication" do
     sign_out :user
     assert_no_difference("Project.count") do

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -533,4 +533,100 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     get project_url(@project, format: :json)
     assert_response :unauthorized
   end
+
+  # --- Templates ---
+
+  test "index lists the current user's template projects, badged as templates" do
+    Project.create!(user: @user, title: "A Uniquely Named Template", is_template: true)
+    get projects_url
+    assert_response :success
+    # A template stays in its owner's list so they can still edit it...
+    assert_includes response.body, "A Uniquely Named Template"
+    # ...but is clearly marked, so they know edits affect what new users start from.
+    assert_includes response.body, "Template"
+    assert_includes response.body, "Edit with care"
+  end
+
+  test "create_from_template duplicates a flagged template into the current user's account" do
+    template = projects(:two)
+    template.update!(is_template: true, title: "Calc Template")
+
+    stub_build_server do
+      assert_difference("Project.count", 1) do
+        post create_from_template_projects_url(template_id: template.id)
+      end
+    end
+
+    copy = Project.find_by!(title: "Calc Template", user: @user)
+    assert_not copy.is_template?
+    assert_equal template.divisions.count, copy.divisions.count
+    assert_redirected_to edit_project_url(copy)
+  end
+
+  test "a failed empty-document create still renders the chooser with its template list" do
+    # An invalid division (blank ref) forces the validation re-render path, which
+    # must still set @templates so the template dialog renders without error.
+    assert_no_difference("Project.count") do
+      post projects_url, params: {
+        project: { title: "X", divisions_attributes: { "0" => { is_root: "true", ref: "", source_format: "pretext" } } }
+      }
+    end
+    assert_response :unprocessable_entity
+    assert_includes response.body, "Start project from template"
+  end
+
+  test "create_from_template refuses a project that is not a template" do
+    non_template = projects(:two)
+    assert_no_difference("Project.count") do
+      post create_from_template_projects_url(template_id: non_template.id)
+    end
+    assert_response :not_found
+  end
+
+  # --- Import ---
+
+  test "create_from_import builds a project from the import payload posted as json" do
+    bytes = file_fixture("test_image.png").binread
+
+    assert_difference("Project.count", 1) do
+      post create_from_import_projects_url,
+        params: {
+          project: {
+            title: "Imported Book",
+            docinfo: "<docinfo/>",
+            document_type: "article",
+            divisions_attributes: [
+              { ref: "document", source_format: "pretext", source: "<article><title>Imported</title></article>", is_root: true }
+            ],
+            assets_attributes: [
+              { ref: "fig-one", kind: "file", title: "fig.png", short_description: "fig.png",
+                file: { filename: "fig.png", content_type: "image/png", data: Base64.strict_encode64(bytes) } }
+            ]
+          }
+        },
+        as: :json
+    end
+
+    assert_response :created
+    project = Project.find_by!(title: "Imported Book", user: @user)
+    assert project.root_division.present?
+    assert_equal "<docinfo/>", project.docinfo
+
+    asset = project.assets.sole
+    assert asset.file.attached?
+    assert_equal "fig.png", asset.file.filename.to_s
+    assert_equal "image/png", asset.file.content_type
+    # The base64 round-trip must reproduce the original bytes exactly.
+    assert_equal bytes, asset.file.download
+
+    assert_equal edit_project_path(project), response.parsed_body["project_url"]
+  end
+
+  test "create_from_import requires authentication" do
+    sign_out :user
+    assert_no_difference("Project.count") do
+      post create_from_import_projects_url, params: { project: { title: "Nope" } }
+    end
+    assert_redirected_to new_user_session_path
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -548,8 +548,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create_from_template duplicates a flagged template into the current user's account" do
-    template = projects(:two)
-    template.update!(is_template: true, title: "Calc Template")
+    template = projects(:template)
 
     stub_build_server do
       assert_difference("Project.count", 1) do

--- a/test/fixtures/divisions.yml
+++ b/test/fixtures/divisions.yml
@@ -13,3 +13,10 @@ two:
   is_root: true
   ref: document
   project: two
+
+template:
+  source: <section><title>Template</title><p>Starter content</p></section>
+  source_format: 0
+  is_root: true
+  ref: document
+  project: template

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -11,3 +11,14 @@ two:
   title: My Second Project
   pretext_source: <pretext><article><section><title>Other</title><p>Content</p></section></article></pretext>
   document_type: article
+
+# A team-curated starter, flagged is_template so it shows up in the
+# "Start project from template" chooser. Owned by user two like any other
+# project -- templates are ordinary projects the admin UI has flagged.
+template:
+  user: two
+  title: Calc Template
+  pretext_source: <pretext><article><section><title>Template</title><p>Starter content</p></section></article></pretext>
+  document_type: article
+  is_template: true
+  template_description: A great starter

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -39,4 +39,27 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal original_id, division.reload.id
     assert_equal "new-xml-id", division.ref
   end
+
+  # --- Templates ---
+
+  test "templates scope returns only flagged projects" do
+    template = projects(:two)
+    template.update!(is_template: true)
+    assert_includes Project.templates, template
+    assert_not_includes Project.templates, projects(:one)
+  end
+
+  test "instantiate_for produces a non-template copy owned by the new user" do
+    template = projects(:one)
+    template.update!(is_template: true, template_description: "A starter")
+    copy = template.instantiate_for(users(:two))
+    stub_build_server { copy.save! }
+
+    assert_equal users(:two), copy.user
+    assert_not copy.is_template?
+    assert_nil copy.template_description
+    # Keeps the template's own title rather than "Copy of ...".
+    assert_equal template.title, copy.title
+    assert_equal template.divisions.count, copy.divisions.count
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -43,19 +43,16 @@ class ProjectTest < ActiveSupport::TestCase
   # --- Templates ---
 
   test "templates scope returns only flagged projects" do
-    template = projects(:two)
-    template.update!(is_template: true)
-    assert_includes Project.templates, template
+    assert_includes Project.templates, projects(:template)
     assert_not_includes Project.templates, projects(:one)
   end
 
   test "instantiate_for produces a non-template copy owned by the new user" do
-    template = projects(:one)
-    template.update!(is_template: true, template_description: "A starter")
-    copy = template.instantiate_for(users(:two))
+    template = projects(:template)
+    copy = template.instantiate_for(users(:one))
     stub_build_server { copy.save! }
 
-    assert_equal users(:two), copy.user
+    assert_equal users(:one), copy.user
     assert_not copy.is_template?
     assert_nil copy.template_description
     # Keeps the template's own title rather than "Copy of ...".

--- a/test/system/asset_modal_loop_test.rb
+++ b/test/system/asset_modal_loop_test.rb
@@ -18,8 +18,8 @@ class AssetModalLoopTest < ApplicationSystemTestCase
 
     visit edit_project_path(project)
 
-    assert_selector "button.pretext-plus-editor__toc-assets-btn", text: "Manage Assets", wait: 20
-    find("button.pretext-plus-editor__toc-assets-btn", text: "Manage Assets").click
+    assert_selector "button.pretext-plus-editor__toc-assets-btn", text: "Manage", wait: 20
+    find("button.pretext-plus-editor__toc-assets-btn", text: "Manage").click
 
     assert_selector "[aria-label='Asset manager']", wait: 10
 


### PR DESCRIPTION
With this change, when a user clicks "New Project" they will be shown three options: start with an empty project, start from a template, and import existing files.  The first gives them the same choices they have now.  The second will show a list of projects that admins have marked as templates (the PR also includes the code to do this from the admin panels: find a user and open their project, then check the box to make it a template).  The third path uses the import project package, allowing the user to upload a file or zip of files to import directly or convert to pretext and import.

Just need a few minor tweaks to the upstream `@pretext-tools/import` and then this will be ready for review.