### PR TITLE
make clear when project is generated from template (to prompt editing the title by user)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -54,7 +54,7 @@ class ProjectsController < ApplicationController
     # Only projects actually flagged as templates are copyable here, regardless
     # of which account owns them.
     template = Project.templates.find(params[:template_id])
-    project = template.instantiate_for(current_user)
+    project = template.instantiate_from_template_for(current_user)
     if project.save
       redirect_to edit_project_path(project)
     else

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -81,9 +81,9 @@ class Project < ApplicationRecord
   # Build a user's own project from this template: a deep copy (divisions,
   # assets, docinfo) via full_dup, but stripped of its template identity and
   # keeping the template's own title rather than "Copy of ...".
-  def instantiate_for(new_owner)
+  def instantiate_from_template_for(new_owner)
     copy = full_dup(new_owner)
-    copy.title = title
+    copy.title = "#{title} (generated from template)"
     copy.is_template = false
     copy.template_description = nil
     copy

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -556,7 +556,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    copy = Project.find_by!(title: "Calc Template", user: @user)
+    copy = Project.find_by!(title: "Calc Template (generated from template)", user: @user)
     assert_not copy.is_template?
     assert_equal template.divisions.count, copy.divisions.count
     assert_redirected_to edit_project_url(copy)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -47,16 +47,16 @@ class ProjectTest < ActiveSupport::TestCase
     assert_not_includes Project.templates, projects(:one)
   end
 
-  test "instantiate_for produces a non-template copy owned by the new user" do
+  test "instantiate_from_template_for produces a non-template copy owned by the new user" do
     template = projects(:template)
-    copy = template.instantiate_for(users(:one))
+    copy = template.instantiate_from_template_for(users(:one))
     stub_build_server { copy.save! }
 
     assert_equal users(:one), copy.user
     assert_not copy.is_template?
     assert_nil copy.template_description
-    # Keeps the template's own title rather than "Copy of ...".
-    assert_equal template.title, copy.title
+    # Adds "generated from template"
+    assert_equal "#{template.title} (generated from template)", copy.title
     assert_equal template.divisions.count, copy.divisions.count
   end
 end


### PR DESCRIPTION
I think most templates should be generic and the user should customize the title, so this prompts to do so.

Also changes method to instantiate from a template to be a bit more clear by its name.