### PR TITLE
Add cdn logic for pdfs

### DIFF
--- a/app/controllers/concerns/serves_build_files.rb
+++ b/app/controllers/concerns/serves_build_files.rb
@@ -15,15 +15,25 @@ module ServesBuildFiles
     #
     # blob_download_url may be missing from an entry cached before it was stored; falling
     # back to the inline URL serves the same bytes, just without the attachment header.
-    def serve_build_file(build, relative_path, disposition: "inline")
+    #
+    # `public:` is only ever true from PublishedController, and only for a target whose
+    # kind is not a site (Target#make_current_build_public! is what actually flips the
+    # object world-readable, on the same condition) -- everything else, including this
+    # same file addressed through the login-only BuildFilesController, keeps getting a
+    # signed URL against the storage provider's own domain.
+    def serve_build_file(build, relative_path, disposition: "inline", public: false)
       file_data = cached_file_data(build, relative_path)
       raise ActiveRecord::RecordNotFound unless file_data
+
+      cdn_host = Rails.application.config.x.cdn_url_options&.dig(:host) if public
 
       if disposition == "attachment"
         redirect_to_cdn_url(file_data[:blob_download_url] || file_data[:blob_url])
       elsif file_data[:content_type] == "text/html"
         content = ActiveStorage::Blob.service.download(file_data[:blob_key])
         send_data content, type: "text/html", disposition: "inline"
+      elsif cdn_host
+        redirect_to_cdn_url "https://#{cdn_host}/#{file_data[:blob_key]}"
       else
         redirect_to_cdn_url file_data[:blob_url]
       end

--- a/app/controllers/concerns/serves_build_files.rb
+++ b/app/controllers/concerns/serves_build_files.rb
@@ -16,24 +16,27 @@ module ServesBuildFiles
     # blob_download_url may be missing from an entry cached before it was stored; falling
     # back to the inline URL serves the same bytes, just without the attachment header.
     #
-    # `public:` is only ever true from PublishedController, and only for a target whose
-    # kind is not a site (Target#make_current_build_public! is what actually flips the
-    # object world-readable, on the same condition) -- everything else, including this
-    # same file addressed through the login-only BuildFilesController, keeps getting a
-    # signed URL against the storage provider's own domain.
+    # `public:` is only ever true from PublishedController, and only once
+    # PublishBuildFilesJob has finished flipping this build's objects world-readable
+    # (Build#files_public?) -- which in turn only happens for a published target whose
+    # kind is not a site. Until that job lands, and for everything else including this
+    # same file addressed through the login-only BuildFilesController, the answer stays
+    # a signed URL against the storage provider's own domain. That fallback is why the
+    # CDN branch can never serve a 403: an object we have not confirmed is public is
+    # simply not addressed by its public URL.
     def serve_build_file(build, relative_path, disposition: "inline", public: false)
       file_data = cached_file_data(build, relative_path)
       raise ActiveRecord::RecordNotFound unless file_data
 
-      cdn_host = Rails.application.config.x.cdn_url_options&.dig(:host) if public
+      cdn = Rails.application.config.x.cdn_url_options if public
 
       if disposition == "attachment"
         redirect_to_cdn_url(file_data[:blob_download_url] || file_data[:blob_url])
       elsif file_data[:content_type] == "text/html"
         content = ActiveStorage::Blob.service.download(file_data[:blob_key])
         send_data content, type: "text/html", disposition: "inline"
-      elsif cdn_host
-        redirect_to_cdn_url "https://#{cdn_host}/#{file_data[:blob_key]}"
+      elsif cdn&.dig(:host)
+        redirect_to_cdn_url "#{cdn.fetch(:protocol, "https")}://#{cdn[:host]}/#{file_data[:blob_key]}"
       else
         redirect_to_cdn_url file_data[:blob_url]
       end

--- a/app/controllers/published_controller.rb
+++ b/app/controllers/published_controller.rb
@@ -23,8 +23,12 @@ class PublishedController < ApplicationController
 
   before_action :load_published_build
 
+  # The CDN is offered only for a build whose files are confirmed world-readable, never
+  # merely for one that ought to be: the flip runs in a background job, and a public URL
+  # sent before it lands would 404 at the reader. files_public? is false for every site
+  # anyway -- nothing enqueues that job for one -- so it subsumes the kind check.
   def show
-    serve_build_file(@build, params[:relative_path], public: !@target.site?)
+    serve_build_file(@build, params[:relative_path], public: @build.files_public?)
   end
 
   # Lands a visitor on the target's entry point -- index.html for a site, the artifact

--- a/app/controllers/published_controller.rb
+++ b/app/controllers/published_controller.rb
@@ -24,7 +24,7 @@ class PublishedController < ApplicationController
   before_action :load_published_build
 
   def show
-    serve_build_file(@build, params[:relative_path])
+    serve_build_file(@build, params[:relative_path], public: !@target.site?)
   end
 
   # Lands a visitor on the target's entry point -- index.html for a site, the artifact

--- a/app/controllers/targets_controller.rb
+++ b/app/controllers/targets_controller.rb
@@ -42,6 +42,7 @@ class TargetsController < ApplicationController
     end
 
     @target.update!(published: publishing)
+    @target.make_current_build_public! if publishing
 
     respond_to do |format|
       format.turbo_stream do

--- a/app/jobs/publish_build_files_job.rb
+++ b/app/jobs/publish_build_files_job.rb
@@ -8,10 +8,19 @@
 class PublishBuildFilesJob < ApplicationJob
   queue_as :default
 
+  # The stamp goes on only after every file is through, and is what PublishedController
+  # checks before handing out a cdn.pretext.plus URL. A raise partway leaves it null, so
+  # readers keep getting signed URLs -- which resolve whatever the ACL says -- instead of
+  # public ones pointing at objects that are still private.
+  #
+  # update_column rather than update!: pure bookkeeping, with no reason to bump the row's
+  # updated_at or wake the broadcasts that hang off a build changing.
   def perform(build)
     build.build_files.with_attached_blob.find_each do |build_file|
       make_public(build_file.blob) if build_file.blob.attached?
     end
+
+    build.update_column(:files_public_at, Time.current)
   end
 
   private

--- a/app/jobs/publish_build_files_job.rb
+++ b/app/jobs/publish_build_files_job.rb
@@ -1,0 +1,27 @@
+# Flips a build's stored files to world-readable, so PublishedController can send a
+# plain cdn.pretext.plus URL instead of a signed one -- see ServesBuildFiles and
+# Target#make_current_build_public!, the only caller.
+#
+# A network call per file, so this runs as a job rather than inline in the model
+# callbacks and controller action that decide a build should be public -- an S3
+# hiccup here must not break an unrelated build transition or the publish request.
+class PublishBuildFilesJob < ApplicationJob
+  queue_as :default
+
+  def perform(build)
+    build.build_files.with_attached_blob.find_each do |build_file|
+      make_public(build_file.blob) if build_file.blob.attached?
+    end
+  end
+
+  private
+
+    # The :test and :local services are Disk, which has no ACL concept -- nothing to
+    # do in development or test, where cdn_url_options is also unset.
+    def make_public(blob)
+      service = blob.service
+      return unless service.respond_to?(:bucket)
+
+      service.bucket.object(blob.key).acl.put(acl: "public-read")
+    end
+end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -35,6 +35,14 @@ class Build < ApplicationRecord
     Target::IN_FLIGHT.include?(status)
   end
 
+  # Whether PublishBuildFilesJob has actually finished making this build's stored files
+  # world-readable, and so whether a plain cdn.pretext.plus URL for them will resolve.
+  # Only ever true for a published single-file target's build -- see
+  # Target#make_current_build_public!, which is the only thing that enqueues that job.
+  def files_public?
+    files_public_at.present?
+  end
+
   # The only way a build's status should ever change.
   #
   # Every transition used to be a bare update_column, which skips callbacks -- fine while

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -224,16 +224,40 @@ class Target < ApplicationRecord
   def sync_from_builds!
     latest = builds.order(created_at: :desc).first
     current = builds.where(status: :success).order(created_at: :desc).first
+    current_changed = current&.id != current_build_id
 
     update_columns(latest_build_id: latest&.id,
                    current_build_id: current&.id,
                    last_built_at: current&.created_at,
                    updated_at: Time.current)
+
+    make_current_build_public! if current_changed
   end
 
   # What "Restore previous build" would fall back to; nil is what hides the button.
   def previous_successful_build
     builds.where(status: :success).order(created_at: :desc).offset(1).first
+  end
+
+  # A site's HTML is streamed straight out of Rails and never takes this path; a
+  # single-file target's artifact (a PDF, an epub) instead redirects to storage, which
+  # is why only these get flipped world-readable -- it is what lets
+  # cdn.pretext.plus serve a plain, cacheable URL instead of a signed one pointing at
+  # the storage provider's own domain (see ServesBuildFiles#serve_build_file).
+  #
+  # Deliberately one-directional: unpublishing does not flip the object back to
+  # private. Doing that safely would also mean purging any CDN cache of it, and the
+  # object is no worse than unguessable once the /o/... route stops resolving --
+  # the same trade a plain "anyone with the link" share already makes.
+  #
+  # Called from both triggers that can make a build "the thing a published target
+  # shows": sync_from_builds! (a new build supersedes the current one) and
+  # TargetsController#publish (the target itself is published, current_build
+  # unchanged).
+  def make_current_build_public!
+    return unless published? && !site? && current_build.present?
+
+    PublishBuildFilesJob.perform_later(current_build)
   end
 
   # Enforces the retention window, called after each build succeeds. Keeps the

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,13 @@ Rails.application.configure do
   # with it. Unset in development, where Codespaces forwards exactly one host.
   config.x.published_url_options = { host: "pub.pretext.plus", protocol: "https" }
 
+  # A single-file target's artifact (a PDF, an epub) is world-readable once its target
+  # is published -- see Target#make_current_build_public! -- so it can be served from
+  # here as a plain, cacheable URL instead of a signed one pointing at the storage
+  # provider's own domain. Unset in development and test, where nothing serves this
+  # domain, so ServesBuildFiles falls back to the existing signed redirect.
+  config.x.cdn_url_options = { host: "cdn.pretext.plus", protocol: "https" }
+
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
   #   user_name: Rails.application.credentials.dig(:smtp, :user_name),

--- a/db/migrate/20260730150000_add_files_public_at_to_builds.rb
+++ b/db/migrate/20260730150000_add_files_public_at_to_builds.rb
@@ -1,0 +1,17 @@
+# When PublishBuildFilesJob finished flipping this build's stored files world-readable.
+# PublishedController reads it (through Build#files_public?) to decide whether it may
+# hand a reader a plain cdn.pretext.plus URL instead of a signed one: the flip happens
+# in a background job, so between publishing a target and that job landing -- or forever,
+# if the storage provider refuses -- the public URL would 404. Recording it is what makes
+# the CDN redirect a consequence of the ACL rather than a bet on it.
+#
+# Per build, not per target: each new build attaches new blobs, which start private.
+#
+# Deliberately left null for builds that predate this column, including ones already made
+# public by an earlier deploy or by cdn:backfill_public_builds. Null only costs a signed
+# redirect, which works either way, and the next build sets it honestly.
+class AddFilesPublicAtToBuilds < ActiveRecord::Migration[8.1]
+  def change
+    add_column :builds, :files_public_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_221129) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -78,6 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_221129) do
   create_table "builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "entry_path"
+    t.datetime "files_public_at"
     t.text "log"
     t.uuid "project_id", null: false
     t.string "remote_status_url"

--- a/lib/tasks/cdn.rake
+++ b/lib/tasks/cdn.rake
@@ -1,0 +1,15 @@
+namespace :cdn do
+  desc "Make already-published single-file targets' current build public, for cdn.pretext.plus"
+  task backfill_public_builds: :environment do
+    count = 0
+
+    Target.where(published: true).find_each do |target|
+      next if target.site? || target.current_build.nil?
+
+      target.make_current_build_public!
+      count += 1
+    end
+
+    puts "Enqueued #{count} target#{"s" unless count == 1} for publishing to the CDN."
+  end
+end

--- a/test/controllers/published_controller_test.rb
+++ b/test/controllers/published_controller_test.rb
@@ -27,6 +27,29 @@ class PublishedControllerTest < ActionDispatch::IntegrationTest
     target.update!(published: true)
   end
 
+  # A published pdf target with one real artifact behind it. `files_public` stands in for
+  # PublishBuildFilesJob having run, which it does not in an integration test.
+  def published_pdf_build(files_public: true)
+    target = projects(:two).targets.create!(name: "Print", kind: "pdf")
+    build = target.builds.create!
+    file = build.build_files.create!(relative_path: "print.pdf")
+    file.blob.attach(io: StringIO.new("%PDF-1.4"), filename: "print.pdf", content_type: "application/pdf")
+    build.mark!(:success, entry_path: "print.pdf")
+    publish!(target)
+    build.update_column(:files_public_at, Time.current) if files_public
+    build
+  end
+
+  # config.x.cdn_url_options is set in production only, so the CDN branch is unreachable
+  # in test without saying so here.
+  def with_cdn_url_options(options)
+    previous = Rails.application.config.x.cdn_url_options
+    Rails.application.config.x.cdn_url_options = options
+    yield
+  ensure
+    Rails.application.config.x.cdn_url_options = previous
+  end
+
   test "anyone can read a published target" do
     publish!
 
@@ -148,6 +171,45 @@ class PublishedControllerTest < ActionDispatch::IntegrationTest
     get published_url(projects(:two), "print")
 
     assert_redirected_to "/o/#{projects(:two).id}/print/print.pdf"
+  end
+
+  # ---- the CDN ----
+
+  test "a public single-file artifact is served from the CDN, not from storage" do
+    build = published_pdf_build
+
+    with_cdn_url_options(host: "cdn.example.com", protocol: "https") do
+      get published_file_url(projects(:two), "print", "print.pdf")
+    end
+
+    assert_redirected_to "https://cdn.example.com/#{build.build_files.sole.blob.key}"
+  end
+
+  # The scheme comes from the same config entry as the host. Hard-coding https here would
+  # keep working right up until the config said otherwise, and then fail silently.
+  test "the CDN redirect uses the configured protocol" do
+    build = published_pdf_build
+
+    with_cdn_url_options(host: "cdn.example.com", protocol: "http") do
+      get published_file_url(projects(:two), "print", "print.pdf")
+    end
+
+    assert_redirected_to "http://cdn.example.com/#{build.build_files.sole.blob.key}"
+  end
+
+  # PublishBuildFilesJob flips the objects world-readable in the background, so for a
+  # moment after publishing -- or for good, if the storage provider refused -- the CDN URL
+  # would 404 at the reader. The signed URL resolves whatever the ACL says, so it is what
+  # goes out until the job has said otherwise.
+  test "an artifact that is not yet public gets a signed url rather than a broken CDN one" do
+    published_pdf_build(files_public: false)
+
+    with_cdn_url_options(host: "cdn.example.com", protocol: "https") do
+      get published_file_url(projects(:two), "print", "print.pdf")
+    end
+
+    assert_response :redirect
+    assert_no_match(/cdn\.example\.com/, response.headers["Location"])
   end
 
   test "an unbuilt target has nowhere to redirect to" do

--- a/test/controllers/targets_controller_test.rb
+++ b/test/controllers/targets_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class TargetsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     @project = projects(:one)
     @target = targets(:one_web)
@@ -290,6 +292,25 @@ class TargetsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert target.reload.published?
+  end
+
+  test "publishing a built single-file target enqueues it to go public" do
+    target = targets(:one_print)
+    build = target.builds.create!
+    build.mark!(:success)
+
+    assert_enqueued_with(job: PublishBuildFilesJob, args: [ build ]) do
+      patch publish_project_target_url(@project, target), params: { published: true }
+    end
+  end
+
+  test "publishing a website enqueues nothing -- its files never go through the CDN" do
+    target = targets(:two_web)
+    sign_in users(:two)
+
+    assert_no_enqueued_jobs(only: PublishBuildFilesJob) do
+      patch publish_project_target_url(projects(:two), target), params: { published: true }
+    end
   end
 
   test "unpublishing is one click back" do

--- a/test/jobs/publish_build_files_job_test.rb
+++ b/test/jobs/publish_build_files_job_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class PublishBuildFilesJobTest < ActiveJob::TestCase
+  test "does nothing against the Disk service used in test/development" do
+    build = builds(:one)
+    file = build.build_files.create!(relative_path: "pdf.pdf")
+    file.blob.attach(io: StringIO.new("%PDF-1.4"), filename: "pdf.pdf", content_type: "application/pdf")
+
+    # The :test service (Disk) has no ACL concept -- this only proves the whole
+    # find_each loop runs without raising. See below for what it does on a service
+    # that has one.
+    PublishBuildFilesJob.perform_now(build)
+
+    assert file.reload.blob.attached?
+  end
+
+  test "flips a blob's object to public-read on a service that has one" do
+    acl = Minitest::Mock.new
+    acl.expect(:put, nil, acl: "public-read")
+    object = Minitest::Mock.new
+    object.expect(:acl, acl)
+    bucket = Minitest::Mock.new
+    bucket.expect(:object, object, [ "some-key" ])
+    fake_service = Struct.new(:bucket).new(bucket)
+    fake_blob = Struct.new(:service, :key).new(fake_service, "some-key")
+
+    PublishBuildFilesJob.new.send(:make_public, fake_blob)
+
+    assert acl.verify
+    assert object.verify
+    assert bucket.verify
+  end
+end

--- a/test/jobs/publish_build_files_job_test.rb
+++ b/test/jobs/publish_build_files_job_test.rb
@@ -3,8 +3,7 @@ require "test_helper"
 class PublishBuildFilesJobTest < ActiveJob::TestCase
   test "does nothing against the Disk service used in test/development" do
     build = builds(:one)
-    file = build.build_files.create!(relative_path: "pdf.pdf")
-    file.blob.attach(io: StringIO.new("%PDF-1.4"), filename: "pdf.pdf", content_type: "application/pdf")
+    file = attach_pdf(build)
 
     # The :test service (Disk) has no ACL concept -- this only proves the whole
     # find_each loop runs without raising. See below for what it does on a service
@@ -30,4 +29,37 @@ class PublishBuildFilesJobTest < ActiveJob::TestCase
     assert object.verify
     assert bucket.verify
   end
+
+  # The stamp is the whole point of the job as far as anything downstream is concerned:
+  # PublishedController will not hand out a CDN URL for a build without it.
+  test "stamps the build once every file is through" do
+    build = builds(:one)
+    attach_pdf(build)
+    assert_not build.files_public?
+
+    PublishBuildFilesJob.perform_now(build)
+
+    assert build.reload.files_public?
+  end
+
+  # A storage provider that refuses must leave the build looking private, or readers get
+  # public URLs for objects that never became public.
+  test "a failure partway leaves the build unstamped" do
+    build = builds(:one)
+    attach_pdf(build)
+
+    job = PublishBuildFilesJob.new
+    job.define_singleton_method(:make_public) { |_blob| raise "the storage provider said no" }
+
+    assert_raises(RuntimeError) { job.perform(build) }
+    assert_not build.reload.files_public?
+  end
+
+  private
+
+    def attach_pdf(build)
+      file = build.build_files.create!(relative_path: "pdf.pdf")
+      file.blob.attach(io: StringIO.new("%PDF-1.4"), filename: "pdf.pdf", content_type: "application/pdf")
+      file
+    end
 end

--- a/test/models/target_test.rb
+++ b/test/models/target_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class TargetTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test "belongs to a project and has many builds" do
     target = targets(:two_web)
     assert_equal projects(:two), target.project
@@ -371,6 +373,64 @@ class TargetTest < ActiveSupport::TestCase
 
     target.builds.create!(created_at: 1.day.ago, status: :success)
     assert_equal older, target.previous_successful_build
+  end
+
+  # ---- making a build public for the CDN ----
+
+  test "publishing a single-file target enqueues its current build to go public" do
+    target = targets(:one_print)
+    build = target.builds.create!
+    build.mark!(:success)
+    target.update!(published: true)
+
+    assert_enqueued_with(job: PublishBuildFilesJob, args: [ build ]) do
+      target.make_current_build_public!
+    end
+  end
+
+  test "make_current_build_public! is a no-op for a site" do
+    target = targets(:two_web)
+    target.update!(published: true)
+
+    assert_no_enqueued_jobs(only: PublishBuildFilesJob) do
+      target.make_current_build_public!
+    end
+  end
+
+  test "make_current_build_public! is a no-op when unpublished or never built" do
+    assert_no_enqueued_jobs(only: PublishBuildFilesJob) do
+      targets(:one_print).make_current_build_public!
+    end
+
+    target = targets(:one_print)
+    target.builds.create!.mark!(:success)
+    assert_no_enqueued_jobs(only: PublishBuildFilesJob) do
+      target.make_current_build_public!
+    end
+  end
+
+  test "a new success on an already-published target is enqueued automatically" do
+    target = targets(:one_print)
+    target.builds.create!.mark!(:success)
+    target.update!(published: true)
+
+    newer = target.builds.create!
+
+    assert_enqueued_with(job: PublishBuildFilesJob, args: [ newer ]) do
+      newer.mark!(:success)
+    end
+  end
+
+  test "a status transition that leaves current_build unchanged enqueues nothing" do
+    target = targets(:one_print)
+    target.builds.create!.mark!(:success)
+    target.update!(published: true)
+    clear_enqueued_jobs
+
+    failing = target.builds.create!
+    assert_no_enqueued_jobs(only: PublishBuildFilesJob) do
+      failing.mark!(:failed)
+    end
   end
 
   test "destroying a target destroys its builds" do


### PR DESCRIPTION
I have already set up the CDN with DO and Cloudflare, so this should work once deployed.

Claude did suggest we do the following:

> Once DNS resolves and the cert issues, run bin/rails cdn:backfill_public_builds in production to make already-published PDFs (etc.) public, then spot-check a real /o/…/pdf link.