### PR TITLE
more robust build setting saving

### DIFF
--- a/app/controllers/publication_settings_controller.rb
+++ b/app/controllers/publication_settings_controller.rb
@@ -21,10 +21,18 @@ class PublicationSettingsController < ApplicationController
     # Merged, not replaced: the form only submits the options the modal offered, and a
     # book-turned-article should not silently lose a setting the modal no longer shows.
     # Blank values are how the form says "inherit"; HasPublicationSettings drops them.
-    if @owner.update(publication_settings: @owner.publication_settings.merge(submitted_settings))
-      redirect_to return_path, notice: "Saved."
-    else
+    #
+    # Merged one setting at a time, too: a modal holds every option of a level, and a value
+    # this level cannot accept is a reason to keep that one setting as it was, not a reason
+    # to throw away the other changes the author made in the same visit.
+    saved, refused = @owner.merge_publication_settings(submitted_settings)
+
+    if !saved
       redirect_to return_path, alert: @owner.errors.full_messages.to_sentence
+    elsif refused.any?
+      redirect_to return_path, alert: refused_alert(refused)
+    else
+      redirect_to return_path, notice: "Saved."
     end
   end
 
@@ -53,6 +61,18 @@ class PublicationSettingsController < ApplicationController
       params.fetch(:publication_settings, {})
             .permit(*Publication::Catalog.keys)
             .to_h
+    end
+
+    # What did not save, and only that -- everything else already has by the time this is
+    # read, so a message about the save as a whole would be wrong. Each line names the
+    # setting left alone, the value that could not be stored, and what one looks like: the
+    # modal is closed by now, so this sentence is all the author has to go back in with.
+    def refused_alert(refused)
+      unsaved = refused.map do |option, value|
+        "#{option.label} is unchanged: “#{value}” is not #{option.guidance}."
+      end
+
+      [ "Saved everything else.", *unsaved ].join(" ")
     end
 
     # Back to the page the modal opened over, with the drawer reopened when it was an

--- a/app/models/concerns/has_publication_settings.rb
+++ b/app/models/concerns/has_publication_settings.rb
@@ -11,16 +11,49 @@ module HasPublicationSettings
 
   included do
     # Blank values mean "inherit", and keys the catalog no longer offers mean nothing at
-    # all, so neither is worth storing. Doing it here rather than in the controller keeps
-    # the column clean whatever writes to it -- including Project#full_dup, which copies
-    # attributes wholesale, and the console.
+    # all, so neither is worth storing. What is left is put in the form the option stores it
+    # in, which for a length is what turns a typed ".25" into "0.25in". Doing all of it here
+    # rather than in the controller keeps the column clean whatever writes to it --
+    # including Project#full_dup, which copies attributes wholesale, and the console.
     normalizes :publication_settings, with: ->(settings) do
-      (settings || {}).to_h.stringify_keys
-        .select { |key, value| Publication::Catalog.find(key) && value.present? }
-        .transform_values(&:to_s)
+      (settings || {}).to_h.stringify_keys.filter_map do |key, value|
+        option = Publication::Catalog.find(key)
+        next unless option
+
+        normalized = option.normalize(value)
+        [ key, normalized ] if normalized.present?
+      end.to_h
     end
 
     validate :publication_settings_are_offered
+  end
+
+  # Saves as much of a submitted set of settings as this level can accept, and answers with
+  # what it had to refuse, as [option, value] pairs.
+  #
+  # An author edits every setting of a level in one modal and saves them together, so an
+  # all-or-nothing write means one mistyped margin costs them the nine changes they made
+  # beside it -- and costs them silently, since the modal is gone by the time they read why.
+  # Each value stands or falls on its own instead: the rest is saved, and a refused key
+  # keeps whatever this level had before rather than being cleared by a typo.
+  #
+  # Settings this level already held are checked too, and dropped if they no longer pass.
+  # That only happens when the catalog stops permitting something already stored, and
+  # dropping it is what keeps such a level saveable at all; it is not reported, because the
+  # author did not submit it.
+  def merge_publication_settings(submitted)
+    submitted = submitted.to_h.stringify_keys
+    previous = publication_settings
+    self.publication_settings = previous.merge(submitted)
+
+    accepted = publication_settings.select { |key, value| Publication::Catalog.find(key).permits?(value) }
+    refused = publication_settings.except(*accepted.keys)
+    restored = previous.slice(*refused.keys)
+                       .select { |key, value| Publication::Catalog.find(key).permits?(value) }
+
+    self.publication_settings = accepted.merge(restored)
+
+    [ save, refused.slice(*submitted.keys).map { |key, value| [ Publication::Catalog.find(key), value ] } ]
   end
 
   private

--- a/app/models/publication/catalog.rb
+++ b/app/models/publication/catalog.rb
@@ -149,18 +149,66 @@ module Publication
     # What a good answer looks like is the option's `hint`, not the kind's: the four sides
     # of a printout margin accept exactly what "all sides" accepts and default to something
     # else entirely, so one hint for the shape would be wrong about four of the five.
-    FreeText = Data.define(:pattern, :max_length)
+    #
+    # `guidance` is the shape said in words, for telling an author what was wrong with what
+    # they typed. `normalizer` is the chance to read a value the way it was plainly meant
+    # before the pattern judges it -- see CANONICAL_LENGTH.
+    FreeText = Data.define(:pattern, :max_length, :guidance, :normalizer) do
+      def self.build(pattern:, max_length:, guidance:, normalizer: nil)
+        new(pattern:, max_length:, guidance:, normalizer:)
+      end
 
-    # A length both consumers understand. The same string is written into a browser's page
-    # margins and into LaTeX's \newgeometry, so the units are the intersection of CSS and
-    # TeX -- which rules out px and rem, legal in one and meaningless in the other.
-    LENGTH = FreeText.new(pattern: /\A\d+(\.\d+)?(in|cm|mm|pt|pc|em|ex)\z/, max_length: 12)
+      # What the author typed, read the way they plainly meant it. A kind with no
+      # normalizer stores what it was given, and so does a value the normalizer cannot make
+      # sense of -- which then fails the pattern and is reported back as it was typed.
+      def normalize(value)
+        return value if normalizer.nil?
+
+        normalizer.call(value).presence || value
+      end
+    end
+
+    # The units a length may carry. Both consumers have to understand it: the same string is
+    # written into a browser's page margins and into LaTeX's \newgeometry, so this is the
+    # intersection of CSS and TeX -- which rules out px and rem, legal in one and
+    # meaningless in the other.
+    LENGTH_UNITS = %w[ in cm mm pt pc em ex ].freeze
+
+    # The shapes of "a number, and maybe a unit" we can read without guessing at intent: a
+    # missing leading zero (".25"), a space or a capital around the unit ("0.25 IN"), or no
+    # unit at all.
+    TYPED_LENGTH = /\A\s*(\d*)(?:\.(\d*))?\s*([a-zA-Z]*)\s*\z/
+
+    # ".25" is a length an author means and neither LaTeX nor CSS reads, and refusing it
+    # teaches nothing that writing "0.25in" back to them does not. A bare number takes
+    # inches, which is the unit PreTeXt's own 0.75in default is in -- and the only guess
+    # here, which is why an unreadable unit is left alone to be refused rather than
+    # coerced into one we invented.
+    #
+    # nil for anything this cannot read, which FreeText#normalize reads as "store what
+    # they typed".
+    CANONICAL_LENGTH = ->(value) do
+      whole, fraction, unit = value.match(TYPED_LENGTH)&.captures
+      next nil if whole.nil?
+
+      unit = unit.downcase
+      next nil unless unit.empty? || LENGTH_UNITS.include?(unit)
+
+      number = fraction.present? ? "#{whole.presence || '0'}.#{fraction}" : whole.presence
+      "#{number}#{unit.presence || 'in'}" if number
+    end
+
+    LENGTH = FreeText.build(pattern: /\A\d+(\.\d+)?(in|cm|mm|pt|pc|em|ex)\z/, max_length: 12,
+                            guidance: "a length with its unit, like 0.75in or 2cm",
+                            normalizer: CANONICAL_LENGTH)
 
     # Words for the corner of a printed page. They travel as a data-* attribute that
     # PreTeXt's own JavaScript prints in the margin, so this permits one line of anything
     # but angle brackets -- which cannot be meant in a header and which the value would
     # pass through an HTML attribute carrying.
-    PRINTOUT_TEXT = FreeText.new(pattern: /\A[^<>\r\n]*\z/, max_length: 100)
+    PRINTOUT_TEXT = FreeText.build(pattern: /\A[^<>\r\n]*\z/, max_length: 100,
+                                   guidance: "one line of text, without < or >, of at " \
+                                             "most 100 characters")
 
     # An option whose list is the project's own uploaded images -- the EPUB cover, which
     # PreTeXt resolves against the external directory, exactly where ProjectArchiveBuilder
@@ -253,6 +301,35 @@ module Publication
         return "#{value} #{choices.unit}" if free_number?
 
         choices_for(document_type).to_h[value] || value
+      end
+
+      # The value as it will be stored: what the author typed, read the way they plainly
+      # meant it. Only a typed option has anything to fix -- a select submits one of its own
+      # values or nothing -- and only a length has a normalizer so far, which turns ".25"
+      # into the "0.25in" that both LaTeX and CSS can read.
+      #
+      # Here rather than in the validation, because what is stored and what is checked have
+      # to be the same string: an option that permitted ".25" and wrote it into a
+      # publication file unchanged would only move the failure to the build.
+      def normalize(value)
+        value = value.to_s.strip
+        free_text? ? choices.normalize(value) : value
+      end
+
+      # The shape of an answer this option accepts, in words, for telling an author what
+      # was wrong with the one they gave. The list options need no such sentence -- a
+      # select cannot submit anything but its own values unless the form was hand-rolled --
+      # so theirs says only that.
+      def guidance
+        if free_number?
+          "a whole number from #{choices.min} to #{choices.max}"
+        elsif free_text?
+          choices.guidance
+        elsif project_scoped?
+          "the name of an image uploaded to this project"
+        else
+          "one of the offered choices"
+        end
       end
 
       # Whether this option accepts the value at all. The single check validation makes,
@@ -623,7 +700,7 @@ module Publication
         #       "and these are their page setup.",
         grids: [
           Grid.build(label: "Margins",
-            note: "A length with its unit (e.g. 0.75in, 2cm). A length in a specific side overrides \"All Sides\" for that side.",
+            note: "A length with its unit (e.g. 0.75in, 2cm); a number on its own is inches. A length in a specific side overrides \"All Sides\" for that side.",
             key_prefix: :worksheet,
             columns: PRINTOUT_MARGINS.map { |key, label, _| [ key, label ] }),
 

--- a/test/controllers/publication_settings_controller_test.rb
+++ b/test/controllers/publication_settings_controller_test.rb
@@ -87,8 +87,61 @@ class PublicationSettingsControllerTest < ActionDispatch::IntegrationTest
 
     patch project_publication_settings_url(@project),
       params: { publication_settings: { braille_page_width: "-4" } }
-    assert_match(/cells per line/, flash[:alert])
+    assert_match(/Cells per line/, flash[:alert])
     assert_equal "32", @project.reload.publication_settings["braille_page_width"]
+  end
+
+  # The modal holds every setting of a level and saves them together, so an all-or-nothing
+  # write means one mistyped margin costs an author the changes they made beside it -- and
+  # costs them silently, since the modal is gone by the time they read the alert. Each
+  # value stands or falls on its own instead.
+  test "one value this level cannot accept does not cost the author the rest" do
+    @project.update!(publication_settings: { "worksheet_margin" => "1in" })
+
+    patch project_publication_settings_url(@project),
+      params: { publication_settings: { worksheet_margin: "1 furlong", theme: "salem",
+                                        chunk_level: "2" } }
+
+    assert_equal({ "worksheet_margin" => "1in", "theme" => "salem", "chunk_level" => "2" },
+                 @project.reload.publication_settings)
+  end
+
+  # And says which setting was left alone, what would not go in it, and what one looks
+  # like: the modal is closed by the time this is read, so the sentence is the whole of
+  # what an author has to go back in with.
+  test "the alert names the refused setting and the shape of a good answer" do
+    patch project_publication_settings_url(@project),
+      params: { publication_settings: { worksheet_top: "1 furlong", theme: "salem" } }
+
+    assert_match(/Saved everything else/, flash[:alert])
+    assert_match(/Top margin is unchanged: “1 furlong” is not a length with its unit/,
+                 flash[:alert])
+    assert_equal({ "theme" => "salem" }, @project.reload.publication_settings)
+  end
+
+  # A refused value leaves the setting as it was rather than clearing it: a typo is not an
+  # instruction to inherit, and the level above taking over is exactly the surprise an
+  # author would not think to look for.
+  test "a refused value keeps what the level had rather than clearing it" do
+    @target.update!(publication_settings: { "theme" => "denver" })
+
+    patch project_target_publication_settings_url(@project, @target),
+      params: { publication_settings: { theme: "not-a-theme" } }
+
+    assert_equal "denver", @target.reload.publication_settings["theme"]
+  end
+
+  # A margin is typed, and the two ways it is typed wrong are a missing leading zero and a
+  # missing unit. Both are values an author means; writing back what they meant beats an
+  # alert that sends them into the modal to add a character.
+  test "a margin typed as a bare or bare-headed number is saved as a length" do
+    patch project_publication_settings_url(@project),
+      params: { publication_settings: { worksheet_margin: ".25", worksheet_left: "1",
+                                        worksheet_right: "0.5 CM" } }
+
+    assert_equal({ "worksheet_margin" => "0.25in", "worksheet_left" => "1in",
+                   "worksheet_right" => "0.5cm" }, @project.reload.publication_settings)
+    assert_equal "Saved.", flash[:notice]
   end
 
   # The EPUB tab appears once the project has an image to be a cover, and the picker

--- a/test/models/publication/settings_test.rb
+++ b/test/models/publication/settings_test.rb
@@ -224,6 +224,66 @@ class Publication::SettingsTest < ActiveSupport::TestCase
     assert_match(/margin on all sides/, @project.errors.full_messages.to_sentence)
   end
 
+  # What an author types and what LaTeX reads are not quite the same language: ".25" and
+  # "0.25 IN" are lengths anyone would recognize and neither \newgeometry nor CSS will
+  # take. They are stored as the length that was meant rather than refused, since refusing
+  # them teaches nothing that writing the value back does not.
+  test "a margin is stored as the length an author meant by it" do
+    {
+      ".25"     => "0.25in",
+      "0.25"    => "0.25in",
+      "3"       => "3in",
+      "0.5 CM"  => "0.5cm",
+      "  2mm  " => "2mm",
+      "0.75in"  => "0.75in"
+    }.each do |typed, stored|
+      @project.publication_settings = { "worksheet_margin" => typed }
+
+      assert_equal stored, @project.publication_settings["worksheet_margin"], typed
+      assert @project.valid?, typed
+    end
+  end
+
+  # The unit is the one guess here -- a bare number takes inches, which is the unit
+  # PreTeXt's own 0.75in default is in. A unit the author did write and we cannot use is
+  # not guessed at: it is kept as typed and refused, so the alert quotes what they typed.
+  test "a margin in units neither LaTeX nor CSS shares is kept as typed and refused" do
+    %w[ 1px 2rem 1inch -1in ].each do |typed|
+      @project.publication_settings = { "worksheet_margin" => typed }
+
+      assert_equal typed, @project.publication_settings["worksheet_margin"]
+      assert_not @project.valid?, typed
+    end
+  end
+
+  # A modal saves every setting of a level at once, so one value it cannot take is a reason
+  # to keep that setting as it was -- not to drop the changes made beside it.
+  test "merging settings keeps what it can and answers with what it could not" do
+    @project.update!(publication_settings: { "worksheet_margin" => "1in" })
+
+    saved, refused = @project.merge_publication_settings(
+      "worksheet_margin" => "1 furlong", "theme" => "salem"
+    )
+
+    assert saved
+    assert_equal [ [ Publication::Catalog.find("worksheet_margin"), "1 furlong" ] ], refused
+    assert_equal({ "worksheet_margin" => "1in", "theme" => "salem" },
+                 @project.reload.publication_settings)
+  end
+
+  # A setting stored before the catalog stopped permitting it would otherwise make the
+  # level unsaveable: every save would fail on a value the author cannot even see, let
+  # alone fix. It is dropped instead, and not reported -- they did not submit it.
+  test "merging drops a stored value the catalog no longer permits, silently" do
+    @project.update_column(:publication_settings, { "theme" => "brooklyn", "chunk_level" => "1" })
+
+    saved, refused = @project.reload.merge_publication_settings("chunk_level" => "2")
+
+    assert saved
+    assert_empty refused
+    assert_equal({ "chunk_level" => "2" }, @project.reload.publication_settings)
+  end
+
   # A header is words an author picks, so it is bounded by a shape rather than a list. The
   # one thing ruled out is angle brackets: they cannot be meant in a page header, and the
   # value passes through an HTML attribute on its way to being printed.

--- a/test/system/drawer_live_update_test.rb
+++ b/test/system/drawer_live_update_test.rb
@@ -71,6 +71,15 @@ class DrawerLiveUpdateTest < ApplicationSystemTestCase
 
     log_box = "##{ActionView::RecordIdentifier.dom_id(@target, :drawer)} pre"
     assert_selector log_box, wait: 10
+
+    # projects/show.html.erb renders this frame with both content and a src, which Turbo
+    # answers with one unconditional, non-morph self-fetch (see the comment there). Setting
+    # the scroll position before that settles is a race: if it lands after we grab
+    # window.__logBox below, it silently replaces the very node we scrolled with a fresh
+    # one at scrollTop 0, and this test would be checking the wrong reload entirely.
+    # Waiting for `complete` pins us to *after* that fetch, so what's left to provoke is
+    # the one the test is actually about: the broadcast-triggered reload.
+    assert_selector "turbo-frame#drawer[complete]", wait: 10
     page.execute_script("document.querySelector('#{log_box}').scrollTop = 200")
     page.execute_script("window.__logBox = document.querySelector('#{log_box}')")
 


### PR DESCRIPTION
As happened today in the demo, changing the build settings but entering a margin for worksheets incorrectly prevented all of them from saving.

This will ensure that only the broken one is not saved.  Also, we are no more clever about guessing what the author meant.  We accept 0.25in when they type .25, .25 IN, etc.