### PR TITLE
supports use of DO Spaces CDN (once custom domain is set up)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,10 +33,29 @@ class ApplicationController < ActionController::Base
 
   def redirect_to_cdn_url(url)
     response.headers["Cache-Control"] = "no-store, private"
-    redirect_to url, allow_other_host: true
+    redirect_to cdn_asset_url(url), allow_other_host: true
   end
 
   private
+
+  # Swaps a DigitalOcean Spaces origin host for the Spaces CDN's custom
+  # subdomain, leaving path and query (which carries the presigned signature)
+  # untouched -- DO's CDN forwards presigned requests to the origin and
+  # validates them there, as long as the URL is virtual-hosted-style (which
+  # storage.yml already produces, since force_path_style is never set). A
+  # no-op when spaces_cdn_host isn't configured, or the URL isn't a Spaces
+  # origin URL (e.g. the local "/icon.svg" and "/image-not-found.svg"
+  # fallback paths).
+  def cdn_asset_url(url)
+    cdn_host = Rails.application.config.x.spaces_cdn_host.presence
+    return url unless cdn_host
+
+    uri = URI.parse(url)
+    return url unless uri.host&.end_with?(".digitaloceanspaces.com")
+
+    uri.host = cdn_host
+    uri.to_s
+  end
 
   def authenticated?
     user_signed_in?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,6 +24,12 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :digitalocean
 
+  # DigitalOcean Spaces CDN custom subdomain fronting the digitalocean storage
+  # service above. ApplicationController#redirect_to_cdn_url rewrites presigned
+  # Spaces origin URLs to this host before redirecting -- see that method for why
+  # storage.yml itself still points at the origin rather than this host.
+  config.x.spaces_cdn_host = "cdn.pretext.plus"
+
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,10 @@ Rails.application.configure do
   # suite actually tests. Integration tests reach it with `host! "pub.example.com"`.
   config.x.published_url_options = { host: "pub.example.com" }
 
+  # Exercise the Spaces CDN host rewrite (see production.rb and
+  # ApplicationController#redirect_to_cdn_url) rather than leaving it unset.
+  config.x.spaces_cdn_host = "cdn.example.com"
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+# Unit coverage for ApplicationController#cdn_asset_url, the private helper
+# redirect_to_cdn_url uses to front DigitalOcean Spaces origin URLs with the
+# Spaces CDN custom subdomain (config.x.spaces_cdn_host, set to
+# "cdn.example.com" in test.rb). No request/response context is needed since
+# the method only reads config and parses/rewrites a URL string.
+class ApplicationControllerTest < ActiveSupport::TestCase
+  setup do
+    @controller = ApplicationController.new
+  end
+
+  test "leaves a relative fallback path unchanged" do
+    assert_equal "/icon.svg", @controller.send(:cdn_asset_url, "/icon.svg")
+  end
+
+  test "leaves a non-Spaces URL unchanged" do
+    url = "https://example.com/foo"
+    assert_equal url, @controller.send(:cdn_asset_url, url)
+  end
+
+  test "rewrites a Spaces origin URL's host to the configured CDN host, preserving path and query" do
+    url = "https://pretext-plus-bucket.nyc3.digitaloceanspaces.com/some/key?X-Amz-Signature=abc&X-Amz-Expires=3600"
+
+    assert_equal "https://cdn.example.com/some/key?X-Amz-Signature=abc&X-Amz-Expires=3600",
+      @controller.send(:cdn_asset_url, url)
+  end
+
+  test "is a no-op when spaces_cdn_host isn't configured" do
+    url = "https://pretext-plus-bucket.nyc3.digitaloceanspaces.com/some/key?X-Amz-Signature=abc"
+
+    Rails.application.config.x.stub(:spaces_cdn_host, nil) do
+      assert_equal url, @controller.send(:cdn_asset_url, url)
+    end
+  end
+end


### PR DESCRIPTION
I believe this is all we need/want to do for CDN support. I think #266 might add some additional functionality, but I think this is the simplest solution to the issue at hand (warnings for DO domains for Spaces files).