### PR TITLE
add hints for XML syntax errors

### DIFF
--- a/packages/web-editor/src/__tests__/wasmPreview.test.ts
+++ b/packages/web-editor/src/__tests__/wasmPreview.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import { describePreviewError, findWellformednessErrorLine } from '../components/wasmPreview'
+
+describe('findWellformednessErrorLine', () => {
+  it('finds the line of a mismatched closing tag', () => {
+    const source = '<pretext>\n<article>\n<p>unclosed\n</article>\n</pretext>'
+    expect(findWellformednessErrorLine(source)).toBe(4)
+  })
+
+  it('returns undefined for well-formed XML', () => {
+    const source = '<pretext>\n<article>\n<p>fine</p>\n</article>\n</pretext>'
+    expect(findWellformednessErrorLine(source)).toBeUndefined()
+  })
+})
+
+describe('describePreviewError', () => {
+  it('names the line when one is given', () => {
+    expect(describePreviewError(new Error('whatever'), 4)).toBe(
+      'Could not build the preview: the document is not well-formed XML ' +
+        '(near line 4) — check for an unclosed or mismatched tag.',
+    )
+  })
+
+  it('falls back to the transform-failure message with no line', () => {
+    expect(describePreviewError(new Error('PreTeXt XSLT transform failed'))).toBe(
+      'Could not build the preview. This usually means the PreTeXt is not ' +
+        'yet well-formed — check for an unclosed tag.',
+    )
+  })
+
+  it('falls back to the raw message for anything else with no line', () => {
+    expect(describePreviewError(new Error('boom'))).toBe('boom')
+  })
+})

--- a/packages/web-editor/src/components/Editors.tsx
+++ b/packages/web-editor/src/components/Editors.tsx
@@ -1552,6 +1552,7 @@ const EditorsInner = (props: EditorsInnerProps) => {
         onRebuild={props.onPreviewRebuild}
         onSyncToSource={handleSyncToSource}
         divisionId={activeDivision?.xmlId}
+        previewLineMap={previewLineMap}
       />
     );
     // For now, we disable the visual editor.  This might come back in a later version:

--- a/packages/web-editor/src/components/LivePreview.tsx
+++ b/packages/web-editor/src/components/LivePreview.tsx
@@ -12,9 +12,11 @@ import {
   describePreviewError,
   findEntryById,
   findEntryForLine,
+  findWellformednessErrorLine,
   isLocalPreviewAvailable,
   renderPreviewHtml,
 } from "./wasmPreview";
+import type { PreviewLineMap } from "./previewSync";
 import type { PtxSourceMap, SourceMapEntry } from "@pretextbook/pretext-html";
 
 interface LivePreviewProps {
@@ -57,6 +59,13 @@ interface LivePreviewProps {
    * on every keystroke and must *not* rebuild.
    */
   divisionId?: string;
+  /**
+   * Translates lines between the editor buffer and the assembled document
+   * that is actually rendered. Used to report a well-formedness error's line
+   * number in terms of what the author sees in Monaco, rather than the
+   * assembled document's own line count.
+   */
+  previewLineMap?: PreviewLineMap | null;
 }
 
 export interface LivePreviewHandle {
@@ -192,7 +201,10 @@ function dismissBrowserTip(): void {
 }
 
 const LivePreview = forwardRef<LivePreviewHandle, LivePreviewProps>(
-  ({ content, title, onRebuild, onSyncToSource, divisionId }, ref) => {
+  (
+    { content, title, onRebuild, onSyncToSource, divisionId, previewLineMap },
+    ref,
+  ) => {
     const [isRebuilding, setIsRebuilding] = useState(false);
     const [browserTipDismissed, setBrowserTipDismissed] = useState(
       isBrowserTipDismissed,
@@ -262,7 +274,12 @@ const LivePreview = forwardRef<LivePreviewHandle, LivePreviewProps>(
               return;
             }
             // Keep whatever is already on screen; only report the failure.
-            setError(describePreviewError(err));
+            const assembledLine = findWellformednessErrorLine(source);
+            const editorLine =
+              assembledLine !== undefined
+                ? previewLineMap?.toEditor(assembledLine)
+                : undefined;
+            setError(describePreviewError(err, editorLine));
           })
           .finally(() => {
             if (token === renderToken.current) {
@@ -277,7 +294,7 @@ const LivePreview = forwardRef<LivePreviewHandle, LivePreviewProps>(
         postToIframe(url, data, "livePreview");
       };
       onRebuild?.(source, previewTitle, postHelper);
-    }, [content, title, onRebuild, renderLocally]);
+    }, [content, title, onRebuild, renderLocally, previewLineMap]);
 
     // Rebuild when the preview opens, and whenever the author switches to a
     // different division — otherwise the page on screen belongs to the

--- a/packages/web-editor/src/components/wasmPreview.ts
+++ b/packages/web-editor/src/components/wasmPreview.ts
@@ -148,14 +148,54 @@ export function findEntryById(
 }
 
 /**
+ * Best-effort line number for a well-formedness failure.
+ *
+ * libxslt discards libxml2's own parse errors (which do carry a line number)
+ * to the console rather than the thrown error — see {@link describePreviewError}
+ * — so this recovers one independently via the browser's own XML parser,
+ * which reports exactly the same well-formedness violations (unclosed or
+ * mismatched tags, stray `&`, etc.) with a line number in its native
+ * `parsererror` output. Neither parser resolves undefined named entities
+ * without a DTD, so the two should never disagree about what counts as
+ * malformed.
+ *
+ * Returns `undefined` when `source` parses cleanly — meaning the actual
+ * failure was something else, e.g. a well-formed document that failed the
+ * XSLT transform — or when a `parsererror` was found but no line number could
+ * be parsed out of it.
+ */
+export function findWellformednessErrorLine(source: string): number | undefined {
+  const doc = new DOMParser().parseFromString(source, "application/xml");
+  const parserError = doc.querySelector("parsererror");
+  const text = parserError?.textContent;
+  if (!text) return undefined;
+  // Chromium: "error on line 7 at column 12: ...". Firefox: "... Line Number
+  // 7, Column 12:". jsdom (used under test): "7:12: unexpected close tag.".
+  const labeled = text.match(/line\s*(?:number)?\D{0,3}(\d+)/i);
+  if (labeled) return Number(labeled[1]);
+  const bare = text.match(/^(\d+):\d+:/);
+  return bare ? Number(bare[1]) : undefined;
+}
+
+/**
  * Turn a render failure into something worth showing an author.
  *
  * libxslt reports parse errors on the console rather than in the thrown
  * error, so the message is often generic; the common authoring case (a
  * malformed document mid-edit) is worth naming explicitly rather than
  * surfacing "PreTeXt XSLT transform failed".
+ *
+ * `line`, when given, comes from {@link findWellformednessErrorLine} and is
+ * already known to be a well-formedness failure — the friendly message is
+ * shown regardless of what `error`'s own text says.
  */
-export function describePreviewError(error: unknown): string {
+export function describePreviewError(error: unknown, line?: number): string {
+  if (line !== undefined) {
+    return (
+      `Could not build the preview: the document is not well-formed XML ` +
+      `(near line ${line}) — check for an unclosed or mismatched tag.`
+    );
+  }
   const message =
     error instanceof Error ? error.message : String(error ?? "Unknown error");
   if (/transform failed/i.test(message)) {


### PR DESCRIPTION
Currently we log errors to console with more information. This exposes line numbers to the user at least. @oscarlevin may have a more clever solution by exposing more features upstream:

> - `@pretextbook/pretext-html` / `@pretextbook/libxslt-wasm` (external npm packages, not part of this repo) discard libxml2/libxslt's structured parse errors to `console.error` and throw only a generic `Error`/`RangeError` with no `.line`/`.column` field and no line number embedded in the message text. There is nothing to extract from `err` itself.