### PR TITLE
use cdn domain redirect for zip and pdf downloads as well

### DIFF
--- a/app/controllers/build_files_controller.rb
+++ b/app/controllers/build_files_controller.rb
@@ -14,6 +14,15 @@ class BuildFilesController < ApplicationController
     serve_build_file(@build, params[:relative_path], disposition: requested_disposition)
   end
 
+  # A site's "Download" is the whole output directory, zipped, rather than a single
+  # build file -- see #show for that case. Its own action (rather than reusing #show)
+  # since the zip is attached directly to the build, not stored as a BuildFile.
+  def zip
+    raise ActiveRecord::RecordNotFound unless @build.zip.attached?
+
+    redirect_to_cdn_url @build.zip.url(disposition: "attachment")
+  end
+
   private
 
     # Only "attachment" is honoured, and only as an exact match: anything else falls back

--- a/app/controllers/concerns/serves_build_files.rb
+++ b/app/controllers/concerns/serves_build_files.rb
@@ -72,7 +72,7 @@ module ServesBuildFiles
           {
             content_type: bf.blob.content_type,
             blob_url: blob_inline_url(bf.blob),
-            blob_download_url: rails_blob_url(bf.blob, disposition: "attachment"),
+            blob_download_url: bf.blob.url(disposition: "attachment"),
             blob_key: bf.blob.key
           },
           unless_exist: true
@@ -80,11 +80,13 @@ module ServesBuildFiles
       end
     end
 
-    # Bypasses Blob#url's forced-binary/forced-attachment logic for content types in
-    # INLINE_OVERRIDE_CONTENT_TYPES by calling the storage service directly, the same way
-    # Asset#url does for uploaded assets.
+    # Calls the storage service directly (as Asset#url does) rather than going through
+    # rails_blob_url, whose redirect route would land on the app's own host -- one hop
+    # too many for redirect_to_cdn_url to rewrite to the Spaces CDN subdomain. This also
+    # bypasses Blob#url's forced-binary/forced-attachment logic for content types in
+    # INLINE_OVERRIDE_CONTENT_TYPES, the same way Asset#url does for uploaded assets.
     def blob_inline_url(blob)
-      return rails_blob_url(blob) unless INLINE_OVERRIDE_CONTENT_TYPES.include?(blob.content_type)
+      return blob.url unless INLINE_OVERRIDE_CONTENT_TYPES.include?(blob.content_type)
 
       blob.service.url(blob.key, expires_in: ActiveStorage.service_urls_expire_in,
         filename: blob.filename, content_type: blob.content_type, disposition: :inline)

--- a/app/views/builds/show.html.erb
+++ b/app/views/builds/show.html.erb
@@ -41,7 +41,7 @@
           target: "_blank", rel: "noopener", data: { turbo: false } %>
   <% end %>
   <% if @build.zip.attached? %>
-    <%= link_to "Download zip", rails_blob_path(@build.zip, disposition: "attachment"),
+    <%= link_to "Download zip", build_zip_path(@build),
           class: "#{button_classes(color: "gray", outlined: true)} px-3 py-2 text-sm",
           data: { turbo: false } %>
   <% end %>

--- a/app/views/targets/_target.html.erb
+++ b/app/views/targets/_target.html.erb
@@ -67,7 +67,7 @@
     <%# A site has no single file to hand over, so its download is the whole output. %>
     <% if target.site? && target.current_build&.zip&.attached? %>
       <%= link_to "Download",
-            rails_blob_path(target.current_build.zip, disposition: "attachment"),
+            build_zip_path(target.current_build),
             class: "#{button_classes(color: "gray", outlined: true)} px-2.5 py-1.5 text-sm",
             data: { turbo: false } %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,7 @@ Rails.application.routes.draw do
   # Deprecated asset share link (used by old builds to serve up assets).
   get "share_assets/external/:id" => "assets#file", as: "share_asset_file"
   get "builds/:build_id/files(/*relative_path)", to: "build_files#show", as: "build_file", format: false
+  get "builds/:build_id/zip", to: "build_files#zip", as: "build_zip"
   resources :asset_fetches, only: :create
   get "tryit" => "projects#tryit"
   post "tryit/preview" => "projects#preview", as: "tryit_preview"

--- a/test/controllers/build_files_controller_test.rb
+++ b/test/controllers/build_files_controller_test.rb
@@ -32,9 +32,12 @@ class BuildFilesControllerTest < ActionDispatch::IntegrationTest
     attach("print.pdf", "%PDF-1.4", "application/pdf")
 
     get build_file_url(@build, "print.pdf", disposition: "attachment")
-
     assert_response :redirect
-    assert_match(/disposition=attachment/, response.location)
+
+    follow_redirect!
+
+    assert_response :success
+    assert_match(/\Aattachment/, response.headers["Content-Disposition"])
   end
 
   # An html artifact -- a reveal.js deck, or a page inside a package -- must still
@@ -43,9 +46,12 @@ class BuildFilesControllerTest < ActionDispatch::IntegrationTest
     attach("deck.html", "<h1>Slides</h1>", "text/html")
 
     get build_file_url(@build, "deck.html", disposition: "attachment")
-
     assert_response :redirect
-    assert_match(/disposition=attachment/, response.location)
+
+    follow_redirect!
+
+    assert_response :success
+    assert_match(/\Aattachment/, response.headers["Content-Disposition"])
   end
 
   # The parameter selects between two fixed behaviours and is never passed through, so it
@@ -83,5 +89,25 @@ class BuildFilesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
     assert_no_match "Chapter One", response.body
+  end
+
+  # What a site's "Download" links to: the whole output directory, zipped, rather than
+  # a single build file.
+  test "zip hands over the build's attached zip as an attachment" do
+    @build.zip.attach(io: StringIO.new("PK\x03\x04"), filename: "site.zip", content_type: "application/zip")
+
+    get build_zip_url(@build)
+    assert_response :redirect
+
+    follow_redirect!
+
+    assert_response :success
+    assert_match(/\Aattachment/, response.headers["Content-Disposition"])
+  end
+
+  test "zip 404s when the build has no zip attached" do
+    get build_zip_url(@build)
+
+    assert_response :not_found
   end
 end


### PR DESCRIPTION
See #266 and #288

This improves the coverage from #288 for PDF and ZIP downloads