### PR TITLE
optional name for new target

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -58,6 +58,7 @@ class Target < ApplicationRecord
   validates :slug, presence: true, format: REF_REGEX, uniqueness: { scope: :project_id },
                    if: -> { name.present? }
 
+  before_validation :generate_default_name, on: :create
   before_validation :assign_slug, on: :create
 
   validate :kind_available_for_document_type
@@ -264,6 +265,30 @@ class Target < ApplicationRecord
   end
 
   private
+
+    # Backs the "Name (optional)" field on the dashboard's add-output form: an author who
+    # doesn't care to type one still gets a row that reads as something instead of hitting
+    # the presence validation below. Runs before assign_slug, which needs a name to derive
+    # from.
+    #
+    # Keyed off kind_label rather than a placeholder like "Untitled" so the generated name
+    # still says what the output is, and deduplicated the same way assign_slug dedupes
+    # slugs -- except the uniqueness this backstops is case-insensitive, so the check here
+    # has to be too.
+    def generate_default_name
+      return if name.present?
+
+      base = kind_label
+      return if base.blank?
+
+      candidate = base
+      suffix = 2
+      while project&.targets&.exists?([ "LOWER(name) = ?", candidate.downcase ])
+        candidate = "#{base} #{suffix}"
+        suffix += 1
+      end
+      self.name = candidate
+    end
 
     # Assigned once, at creation, and never recomputed: the slug is in a public URL and in
     # `pretext build <slug>` on a downloaded copy, so renaming an output on the dashboard

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -73,13 +73,13 @@
       <summary class="cursor-pointer text-sm text-gray-600">+ Add an output</summary>
       <%= form_with model: [ @project, Target.new ], class: "mt-4 flex flex-wrap items-end gap-3" do |form| %>
         <div>
-          <%= form.label :name, "Name", class: "block text-xs text-gray-600" %>
-          <%= form.text_field :name, placeholder: "Print PDF", required: true,
+          <%= form.label :kind, "Output format", class: "block text-xs text-gray-600" %>
+          <%= form.select :kind, target_kind_options(@project), {},
                 class: "mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm" %>
         </div>
         <div>
-          <%= form.label :kind, "Output format", class: "block text-xs text-gray-600" %>
-          <%= form.select :kind, target_kind_options(@project), {},
+          <%= form.label :name, "Name (optional)", class: "block text-xs text-gray-600" %>
+          <%= form.text_field :name, placeholder: "Print PDF", required: false,
                 class: "mt-1 rounded-md border border-gray-300 px-2 py-1.5 text-sm" %>
         </div>
         <%= form.submit "Add output",

--- a/test/models/target_test.rb
+++ b/test/models/target_test.rb
@@ -52,13 +52,32 @@ class TargetTest < ActiveSupport::TestCase
     assert_equal "Print run", projects(:one).targets.create!(name: "  Print run  ", kind: "pdf").name
   end
 
-  # An author who left the name blank made one mistake; the flash used to report it three
-  # times, twice about a field the form does not have.
-  test "a nameless target reports only the missing name" do
-    target = Target.new(project: projects(:one), kind: "pdf")
+  # The dashboard's add-output form labels the field "Name (optional)" -- an author who
+  # skips it still gets a row that reads as something, keyed off the kind they picked.
+  test "a target left nameless is named after its kind" do
+    target = projects(:one).targets.create!(kind: "pdf")
+
+    assert_equal "PDF", target.name
+  end
+
+  # Two nameless PDFs in one project can't collide any more than two typed-out "PDF"s
+  # could -- the generated name goes through the same case-insensitive dedupe.
+  test "two nameless targets of the same kind get distinct generated names" do
+    first = projects(:one).targets.create!(kind: "pdf")
+    second = projects(:one).targets.create!(kind: "pdf")
+
+    assert_equal "PDF", first.name
+    assert_equal "PDF 2", second.name
+  end
+
+  # A blank kind humanizes to nothing to generate a name from (unlike an invalid-but-
+  # nonblank one, which still yields something readable), so the presence validation is
+  # still what an author sees for the name field.
+  test "a target with a blank kind and no name still gets a required-name error" do
+    target = Target.new(project: projects(:one), kind: "")
 
     assert_not target.valid?
-    assert_equal [ "Name can't be blank" ], target.errors.full_messages
+    assert_includes target.errors[:name], "can't be blank"
   end
 
   # The decision that shapes the schema: the *slug* is the unique key, not `kind`,


### PR DESCRIPTION
Removes requirement to manually name each new target