### PR TITLE
Alert when collaborative editing's live relay fails

### DIFF
--- a/app/controllers/cable_health_controller.rb
+++ b/app/controllers/cable_health_controller.rb
@@ -1,0 +1,104 @@
+# Liveness for the *relay*, as distinct from liveness for the app.
+#
+# `/up` answers "is this process serving HTTP", which stayed true throughout the
+# August 2026 collaboration outage and is exactly why nothing alerted. What breaks
+# collaborative editing is narrower: solid_cable's listener thread. It polls the
+# separate cable database (see config/cable.yml and the `cable` entry in
+# database.yml) and hands broadcasts to subscribers, and it is startlingly easy to
+# lose --
+#
+#   @thread = Thread.new do
+#     begin
+#       listen
+#     rescue *CONNECTION_ERRORS   # only ConnectionFailed/Timeout/NotEstablished
+#       retry if retry_connecting? # ...and only a bounded number of times
+#     end
+#   end
+#
+# -- so any error that isn't one of those three kills it outright, and one of those
+# three kills it too once the bounded retries are spent. The thread does not come
+# back. The process goes on serving every HTTP request perfectly while delivering no
+# broadcast to anyone, forever, until it is restarted. Which is why a redeploy
+# "fixed" an outage that no deploy had caused.
+#
+# This endpoint publishes a token through the configured pubsub and waits to hear it
+# back, so it fails exactly when that thread is gone.
+#
+# Two things to know when reading its result:
+#
+# * It reports on *the process that served the request*. Under multiple Puma workers
+#   a monitor will land on them round-robin, so one wedged worker shows up as an
+#   intermittent failure, not a steady one. Treat any failure as real.
+# * It is deliberately not part of `/up`. A container orchestrator restarting the app
+#   because the cable database blipped would be a worse outage than the one this
+#   catches; point a monitor at it and alert, don't wire it to a liveness probe.
+class CableHealthController < ApplicationController
+  allow_unauthenticated_access
+
+  # A round trip is a database write, a poll (0.1s in production) and a callback, so
+  # this is roughly two orders of magnitude more than a healthy relay needs. It is a
+  # ceiling on how long a wedged relay ties up this thread, not a target.
+  TIMEOUT = 3.seconds
+
+  # The request holds a thread for up to TIMEOUT, so it is worth a ceiling even
+  # though it is only ever meant to be called by a monitor every minute or so.
+  rate_limit to: 60, within: 1.minute, only: :show, with: -> { head :too_many_requests }
+
+  def show
+    silent_for = round_trip
+
+    if silent_for
+      render plain: "ok (relay round-tripped in #{(silent_for * 1000).round}ms)"
+    else
+      # Notified from here rather than left to the monitor because this is the one
+      # place that knows *which* process failed, and that is most of the diagnosis.
+      Honeybadger.notify(
+        "Collaborative editing relay is not delivering broadcasts",
+        error_class: "Collab::RelayDown",
+        context: {
+          timeout_seconds: TIMEOUT.to_i,
+          adapter: ActionCable.server.config.cable&.dig("adapter"),
+          pid: Process.pid,
+          hostname: Socket.gethostname
+        }
+      )
+      render plain: "cable relay did not round-trip within #{TIMEOUT.to_i}s", status: :service_unavailable
+    end
+  end
+
+  private
+
+    # Seconds the round trip took, or nil if the token never came back.
+    def round_trip
+      token = SecureRandom.hex(16)
+      channel = "cable-health/#{token}"
+      pubsub = ActionCable.server.pubsub
+
+      received = Thread::Queue.new
+      subscribed = Thread::Queue.new
+      callback = ->(message) { received.push(message) }
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      begin
+        # Broadcasting before the subscription is live would race, and would fail
+        # this check on a *healthy* relay -- the success callback is what makes the
+        # negative result mean something.
+        pubsub.subscribe(channel, callback, -> { subscribed.push(true) })
+        return nil unless subscribed.pop(timeout: TIMEOUT)
+
+        pubsub.broadcast(channel, token)
+        return nil unless received.pop(timeout: TIMEOUT) == token
+
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      ensure
+        # A per-request channel that outlived its request would leave the listener
+        # polling for a token nobody is waiting for, once per health check, forever.
+        pubsub.unsubscribe(channel, callback)
+      end
+    rescue StandardError => error
+      # A raise here is itself a red flag (the adapter could not even be reached),
+      # and is reported as the failure it is rather than as a 500.
+      Rails.logger.error("[cable-health] #{error.class}: #{error.message}")
+      nil
+    end
+end

--- a/app/controllers/collab_incidents_controller.rb
+++ b/app/controllers/collab_incidents_controller.rb
@@ -1,0 +1,79 @@
+# Where the editor reports collaboration failures it can see but the server cannot.
+#
+# Every *other* part of a collaborative session is ordinary HTTP on the primary
+# database -- joining (ProjectDocsController#show), seeding, compaction, autosave --
+# and all of it keeps working when the live relay dies. The relay itself is
+# ActionCable over solid_cable against a separate database, and a client whose
+# updates stop being broadcast looks, from here, exactly like a client that is
+# simply idle. Nothing raises, nothing 500s, and the first anyone hears of it is a
+# user saying "my collaborator can't see my edits" -- which is how the August 2026
+# outage was found.
+#
+# So the browser is the only witness, and this is where it testifies. There is no
+# JavaScript Honeybadger in this app; reports come here and are notified from Ruby,
+# which also keeps the API key out of the bundle.
+class CollabIncidentsController < ApplicationController
+  # What a client is allowed to report. Anything else is a bug or a forgery, and
+  # either way must not become a new error class in Honeybadger: the point of a
+  # fixed list is that these are alertable *because* they are few and known.
+  #
+  # `relay_recovered` is reported so a stall can be read as an episode with an end
+  # rather than an open question. It is the one kind here that is not itself a
+  # problem, so mute it in Honeybadger if it turns out to be noisy -- but read it
+  # first, because a stall that never recovers means the process stayed wedged,
+  # which is the case that needs a restart.
+  KINDS = %w[ join_failed relay_stalled relay_recovered ].freeze
+
+  # Free text from the browser (an exception message, usually). Bounded because it
+  # is written into an error tracker, and an unbounded field pointed at an error
+  # tracker is a way to lose the signal.
+  MAX_DETAIL_LENGTH = 500
+
+  # Generous enough that a session in real trouble reports its stall, its recovery
+  # and a couple of relapses, tight enough that a client stuck in a report loop
+  # cannot turn Honeybadger into a firehose. The watchdog already reports each
+  # episode once (see yCableProvider), so hitting this at all means something is
+  # wrong with the reporting, and dropping those is the right outcome.
+  rate_limit to: 10, within: 10.minutes, only: :create, with: -> { head :too_many_requests }
+
+  def create
+    kind = params[:kind].to_s
+    return head :unprocessable_entity unless KINDS.include?(kind)
+
+    project = Project.find_by(id: params[:project_id])
+    # The report is *about* a collaborative session, so it is only meaningful from
+    # someone who could be in one. This also keeps the project ids that reach
+    # Honeybadger to ones the reporter genuinely has, so context can be trusted
+    # while investigating.
+    return head :forbidden unless project && current_ability.can?(:update, project)
+
+    report(kind, project)
+    head :accepted
+  end
+
+  private
+
+    def report(kind, project)
+      context = {
+        project_id: project.id,
+        user_id: current_user.id,
+        kind: kind,
+        detail: params[:detail].to_s.truncate(MAX_DETAIL_LENGTH).presence,
+        # How long the relay had been silent (relay_stalled) or was silent before it
+        # came back (relay_recovered), in seconds. The difference between "a blip
+        # during a deploy" and "this process has been deaf for an hour".
+        silent_for_seconds: params[:silent_for_seconds].presence&.to_i,
+        user_agent: request.user_agent
+      }.compact
+
+      # One error class per kind, so alerting can be set per failure rather than on
+      # one bucket that mixes "could not join" with "recovered".
+      Honeybadger.notify(
+        "Collaborative editing: #{kind.humanize.downcase}",
+        error_class: "Collab::#{kind.camelize}",
+        context: context
+      )
+
+      Rails.logger.warn("[collab-incident] #{context.to_json}")
+    end
+end

--- a/app/javascript/controllers/react/collab/reportIncident.js
+++ b/app/javascript/controllers/react/collab/reportIncident.js
@@ -1,0 +1,51 @@
+/**
+ * Reports a collaboration failure to the server, which forwards it to
+ * Honeybadger (see CollabIncidentsController).
+ *
+ * There is no JavaScript error tracker in this app, and the failures worth
+ * knowing about here are ones the server cannot see for itself: a client that
+ * never joined, or one whose relay went quiet while every HTTP request it makes
+ * keeps succeeding. Both look like an idle user from the server's side.
+ *
+ * Never throws and never rejects. Every caller is already on a failure path, and
+ * an error reporter that can itself fail is a way to turn a degraded session
+ * into a broken one. `keepalive` so a report sent as the tab goes away still
+ * gets out.
+ *
+ * @param {Object} incident
+ * @param {"join_failed"|"relay_stalled"|"relay_recovered"} incident.kind
+ * @param {string} incident.projectId
+ * @param {string} [incident.csrfToken]
+ * @param {string} [incident.detail] Free text, truncated server-side.
+ * @param {number} [incident.silentForSeconds] How long the relay was quiet.
+ * @returns {Promise<void>}
+ */
+export async function reportCollabIncident({
+  kind,
+  projectId,
+  csrfToken,
+  detail,
+  silentForSeconds,
+}) {
+  try {
+    await fetch("/collab_incidents", {
+      method: "POST",
+      keepalive: true,
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "X-CSRF-Token": csrfToken,
+      },
+      body: JSON.stringify({
+        kind,
+        project_id: projectId,
+        detail,
+        silent_for_seconds: silentForSeconds,
+      }),
+    });
+  } catch {
+    // Reporting is best-effort by construction: if the network is down badly
+    // enough that this fails, the session has larger problems and the user is
+    // already being told about them.
+  }
+}

--- a/app/javascript/controllers/react/collab/yCableProvider.js
+++ b/app/javascript/controllers/react/collab/yCableProvider.js
@@ -7,6 +7,7 @@ import {
   removeAwarenessStates,
 } from "y-protocols/awareness";
 import { seedDocFromState } from "@pretextbook/web-editor";
+import { reportCollabIncident } from "./reportIncident";
 
 /**
  * Yjs provider over ActionCable + the project-doc HTTP endpoints.
@@ -29,22 +30,38 @@ import { seedDocFromState } from "@pretextbook/web-editor";
  * full doc state with the highest update id it has incorporated; the server
  * swaps the snapshot and deletes only rows up to that id.
  *
+ * Relay watchdog: the channel broadcasts to every subscriber *including the
+ * sender*, so this client's own awareness heartbeat comes back to it every
+ * AWARENESS_HEARTBEAT_MS. That makes inbound traffic a liveness signal for the
+ * whole relay even in a session of one, and its absence the one symptom that
+ * distinguishes "nobody is typing" from "broadcasts are going nowhere" -- the
+ * August 2026 outage, where solid_cable's listener thread had died in a Puma
+ * worker and every HTTP request kept succeeding. See `startWatchdog`.
+ *
  * @typedef {Object} ProviderConfig
  * @property {string} projectId
  * @property {string} [csrfToken]
  * @property {{name: string, color: string}} user
+ * @property {(status: "ready"|"stalled") => void} [onRelayStatusChange]
  */
 
 const AWARENESS_HEARTBEAT_MS = 15000; // y-protocols expires peers after 30s
 const COMPACTION_INTERVAL_MS = 60000;
 const COMPACTION_MIN_UPDATES = 20;
+// How often the watchdog looks, and how much silence it takes to call the relay
+// stalled. Two and a half missed heartbeats: long enough that one dropped
+// message or a slow poll is not an incident, short enough that a user is still
+// looking at the screen when the banner appears.
+const RELAY_WATCHDOG_MS = 10000;
+const RELAY_SILENCE_MS = AWARENESS_HEARTBEAT_MS * 2.5;
 
 export class YCableProvider {
   /** @param {ProviderConfig} config */
-  constructor({ projectId, csrfToken, user }) {
+  constructor({ projectId, csrfToken, user, onRelayStatusChange }) {
     this.projectId = projectId;
     this.csrfToken = csrfToken;
     this.user = user;
+    this.onRelayStatusChange = onRelayStatusChange ?? (() => {});
     this.doc = new Y.Doc();
     this.awareness = new Awareness(this.doc);
     // Per-tab identity for filtering our own cable echoes (we still read the
@@ -64,6 +81,11 @@ export class YCableProvider {
     this.consumer = null;
     this.subscription = null;
     this.intervals = [];
+    // Watchdog state. `relayStatus` is "ready" until proven otherwise, so a
+    // session that never stalls never mentions the relay to anyone.
+    this.relayStatus = "ready";
+    this.lastInboundAt = 0;
+    this.stalledSince = null;
   }
 
   /**
@@ -117,12 +139,95 @@ export class YCableProvider {
       setInterval(() => this.maybeCompact(), COMPACTION_INTERVAL_MS),
     );
 
+    this.startWatchdog();
+
     // Best-effort presence cleanup; if it doesn't get out, peers expire us
     // after the awareness timeout anyway.
     this.onPageHide = () => {
       removeAwarenessStates(this.awareness, [this.awareness.clientID], "pagehide");
     };
     window.addEventListener("pagehide", this.onPageHide);
+  }
+
+  // ── Relay watchdog ─────────────────────────────────────────────────────────
+
+  /**
+   * Watches for the relay going quiet, and keeps the session usable when it
+   * does.
+   *
+   * The signal is plain silence. Our own awareness heartbeat is echoed back to
+   * us by the channel every AWARENESS_HEARTBEAT_MS, so a healthy relay cannot be
+   * quiet for RELAY_SILENCE_MS no matter how idle the humans are; a quiet relay
+   * is a broken one. That is what makes this catch the failure that HTTP checks
+   * cannot see, in a session of one as readily as in a session of five.
+   *
+   * While stalled it re-fetches over HTTP on every tick. This is not just
+   * bookkeeping: when the relay dies the way it died in August, the *broadcast*
+   * leg is what's gone -- `doc_update` still reaches the server and is still
+   * appended to `project_doc_updates` -- so peers' edits are all still there to
+   * be read. Polling turns a silently diverging session into a slow one.
+   * @returns {void}
+   */
+  startWatchdog() {
+    this.lastInboundAt = Date.now();
+
+    // A hidden tab has its timers throttled, our heartbeat included, so silence
+    // measured across a spell in the background says nothing about the relay.
+    this.onVisibilityChange = () => {
+      if (document.visibilityState === "visible") this.lastInboundAt = Date.now();
+    };
+    document.addEventListener("visibilitychange", this.onVisibilityChange);
+
+    this.intervals.push(
+      setInterval(() => this.checkRelay(), RELAY_WATCHDOG_MS),
+    );
+  }
+
+  /** @returns {void} */
+  checkRelay() {
+    if (this.destroyed) return;
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
+
+    const silentFor = Date.now() - this.lastInboundAt;
+    if (silentFor < RELAY_SILENCE_MS) return;
+
+    if (this.relayStatus === "ready") {
+      this.relayStatus = "stalled";
+      this.stalledSince = this.lastInboundAt;
+      this.onRelayStatusChange("stalled");
+      reportCollabIncident({
+        kind: "relay_stalled",
+        projectId: this.projectId,
+        csrfToken: this.csrfToken,
+        detail: "No cable message received since the last awareness heartbeat echo.",
+        silentForSeconds: Math.round(silentFor / 1000),
+      });
+    }
+
+    // Every tick while stalled, not just on the transition: this is the session's
+    // only remaining path to peers' edits.
+    this.scheduleResync();
+  }
+
+  /**
+   * Any inbound cable message is proof the relay is delivering. Called for every
+   * message, including ones buffered before the session is ready.
+   * @returns {void}
+   */
+  noteInbound() {
+    this.lastInboundAt = Date.now();
+    if (this.relayStatus !== "stalled") return;
+
+    const silentFor = this.stalledSince ? Date.now() - this.stalledSince : null;
+    this.relayStatus = "ready";
+    this.stalledSince = null;
+    this.onRelayStatusChange("ready");
+    reportCollabIncident({
+      kind: "relay_recovered",
+      projectId: this.projectId,
+      csrfToken: this.csrfToken,
+      silentForSeconds: silentFor ? Math.round(silentFor / 1000) : undefined,
+    });
   }
 
   /** True when this client should run session-wide chores (autosave, compaction). */
@@ -137,6 +242,7 @@ export class YCableProvider {
   destroy() {
     this.destroyed = true;
     window.removeEventListener("pagehide", this.onPageHide ?? (() => {}));
+    document.removeEventListener("visibilitychange", this.onVisibilityChange ?? (() => {}));
     this.intervals.forEach(clearInterval);
     this.intervals = [];
     removeAwarenessStates(this.awareness, [this.awareness.clientID], "destroy");
@@ -175,6 +281,7 @@ export class YCableProvider {
             }
           },
           received: (message) => {
+            this.noteInbound();
             if (!this.ready) {
               this.buffered.push(message);
               return;

--- a/app/javascript/controllers/react/editor.jsx
+++ b/app/javascript/controllers/react/editor.jsx
@@ -14,6 +14,7 @@ import {
   docToState,
 } from "@pretextbook/web-editor";
 import { YCableProvider } from "./collab/yCableProvider";
+import { reportCollabIncident } from "./collab/reportIncident";
 import {
   railsDivisionToEditor,
   railsAssetToEditor,
@@ -443,6 +444,10 @@ function EditorApp({ config }) {
   // the collab-mode dirty-check baseline, mirroring serverSnapshot.
   const collabServerSnapshot = useRef(null);
   const [collabStatus, setCollabStatus] = useState("off"); // off|connecting|ready|error
+  // Whether live relay is currently flowing. Separate from collabStatus: the
+  // session is joined and fully usable, it just isn't hearing peers in real time
+  // (see YCableProvider.startWatchdog), so this warns rather than blocks.
+  const [relayStalled, setRelayStalled] = useState(false);
 
   useEffect(() => {
     const data = projectQuery.data;
@@ -454,6 +459,7 @@ function EditorApp({ config }) {
         name: data.editorUser?.name || "Anonymous",
         color: colorForUser(data.editorUser?.id),
       },
+      onRelayStatusChange: (status) => setRelayStalled(status === "stalled"),
     });
     providerRef.current = provider;
     setCollabStatus("connecting");
@@ -469,6 +475,15 @@ function EditorApp({ config }) {
       .catch((error) => {
         console.error("Failed to join collaborative session:", error);
         setCollabStatus("error");
+        // The user sees a "please reload" screen and will usually just reload,
+        // so without this the only record of a session nobody could join is a
+        // message in a console nobody is reading.
+        reportCollabIncident({
+          kind: "join_failed",
+          projectId,
+          csrfToken,
+          detail: error?.message ?? String(error),
+        });
       });
   }, [projectQuery.data, projectId, csrfToken]);
 
@@ -1093,47 +1108,60 @@ function EditorApp({ config }) {
   const state = initial.current;
   const provider = providerRef.current;
   return (
-    <Editors
-      title={state.title}
-      docinfo={state.docinfo}
-      commonDocinfo={state.commonDocinfo}
-      useCommonDocinfo={state.useCommonDocinfo}
-      projectType={state.projectType}
-      divisions={state.divisions}
-      rootDivisionId={state.rootDivisionId}
-      collaboration={
-        provider
-          ? {
-              doc: provider.doc,
-              awareness: provider.awareness,
-              user: provider.user,
-            }
-          : undefined
-      }
-      projectAssets={projectAssets}
-      projectUrl={projectUrl}
-      saveButtonLabel="Save and manage"
-      cancelButtonLabel="Cancel"
-      onContentChange={onContentChange}
-      onDivisionAdd={onDivisionAdd}
-      onDivisionRemove={onDivisionRemove}
-      onDivisionUpdate={onDivisionUpdate}
-      onAssetInsert={onAssetInsert}
-      onAssetUpload={onAssetUpload}
-      onAssetFetchUrl={onAssetFetchUrl}
-      onAssetUpdate={onAssetUpdate}
-      onAssetRemove={onAssetRemove}
-      onLoadAssets={onLoadAssets}
-      onTitleChange={onTitleChange}
-      onUseCommonDocinfoChange={onUseCommonDocinfoChange}
-      onCommonDocinfoChange={onCommonDocinfoChange}
-      onSave={() => save()}
-      onSaveButton={onSaveButton}
-      onCancelButton={onCancelButton}
-      onPreviewRebuild={onPreviewRebuild}
-      onCreatePretextProjectCopy={onCreatePretextProjectCopy}
-      onFeedbackSubmit={onFeedbackSubmit}
-    />
+    <>
+      {/* Positioned rather than laid out, so a banner that appears mid-session
+          cannot reflow the editor under the user's cursor. Reassuring on
+          purpose: their work is safe and still being saved -- what they have
+          lost is only the *live* view of collaborators, and telling them that
+          plainly is better than letting them discover it by contradiction. */}
+      {relayStalled && (
+        <div class="fixed top-2 left-1/2 z-50 -translate-x-1/2 rounded-md border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-900 shadow-md">
+          Live collaboration is interrupted — your work is still being saved, and
+          collaborators’ changes will now take a few seconds to appear.
+        </div>
+      )}
+      <Editors
+        title={state.title}
+        docinfo={state.docinfo}
+        commonDocinfo={state.commonDocinfo}
+        useCommonDocinfo={state.useCommonDocinfo}
+        projectType={state.projectType}
+        divisions={state.divisions}
+        rootDivisionId={state.rootDivisionId}
+        collaboration={
+          provider
+            ? {
+                doc: provider.doc,
+                awareness: provider.awareness,
+                user: provider.user,
+              }
+            : undefined
+        }
+        projectAssets={projectAssets}
+        projectUrl={projectUrl}
+        saveButtonLabel="Save and manage"
+        cancelButtonLabel="Cancel"
+        onContentChange={onContentChange}
+        onDivisionAdd={onDivisionAdd}
+        onDivisionRemove={onDivisionRemove}
+        onDivisionUpdate={onDivisionUpdate}
+        onAssetInsert={onAssetInsert}
+        onAssetUpload={onAssetUpload}
+        onAssetFetchUrl={onAssetFetchUrl}
+        onAssetUpdate={onAssetUpdate}
+        onAssetRemove={onAssetRemove}
+        onLoadAssets={onLoadAssets}
+        onTitleChange={onTitleChange}
+        onUseCommonDocinfoChange={onUseCommonDocinfoChange}
+        onCommonDocinfoChange={onCommonDocinfoChange}
+        onSave={() => save()}
+        onSaveButton={onSaveButton}
+        onCancelButton={onCancelButton}
+        onPreviewRebuild={onPreviewRebuild}
+        onCreatePretextProjectCopy={onCreatePretextProjectCopy}
+        onFeedbackSubmit={onFeedbackSubmit}
+      />
+    </>
   );
 }
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -25,3 +25,19 @@ production:
       writing: cable
   polling_interval: 0.1.seconds
   message_retention: 1.day
+  # Seconds to wait before each attempt to reconnect the listener thread to the
+  # cable database. The default is `1`, which solid_cable expands to `[0]`: one
+  # retry, immediately, no backoff. Spend that on a database that is still coming
+  # back and the thread stops for good --
+  #
+  #   rescue *CONNECTION_ERRORS
+  #     retry if retry_connecting?   # false once the attempts are used up
+  #   end
+  #
+  # -- and a listener thread that has stopped takes every broadcast in that
+  # process with it, silently and permanently, while HTTP keeps serving. That is
+  # the August 2026 collaboration outage, and a few seconds of managed-database
+  # failover is all it takes to reproduce. This rides out just over a minute of it.
+  # Note the ceiling is real: past this the process still needs a restart, which is
+  # what /up/cable is for (see CableHealthController).
+  reconnect_attempts: [ 0, 1, 2, 4, 8, 16, 32 ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,7 +169,14 @@ Rails.application.routes.draw do
   post "tryit/preview" => "projects#preview", as: "tryit_preview"
   get "(tryit)/external/icon" => redirect("/icon.svg")
 
+  # Where the editor reports collaboration failures only the browser can see.
+  resources :collab_incidents, only: :create
+
   get "up" => "rails/health#show", as: :rails_health_check
+  # Deliberately *not* folded into /up: this one can fail while the app is
+  # perfectly healthy, and restarting the app over it would be the worse outage.
+  # Point a monitor at it and alert on it. See CableHealthController.
+  get "up/cable" => "cable_health#show", as: :cable_health_check
 
   root "pages#home"
 end

--- a/test/controllers/cable_health_controller_test.rb
+++ b/test/controllers/cable_health_controller_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+class CableHealthControllerTest < ActionDispatch::IntegrationTest
+  test "reports ok when a broadcast round-trips through the relay" do
+    get cable_health_check_url
+
+    assert_response :success
+    assert_match(/\Aok /, response.body)
+  end
+
+  test "does not require a signed-in user, so a monitor can call it" do
+    get cable_health_check_url
+
+    assert_response :success
+  end
+
+  test "reports service unavailable and notifies when the relay never delivers" do
+    notified = capture_notifications do
+      # A pubsub that accepts the subscription and then swallows the broadcast is
+      # exactly the shape of the failure this exists to catch: solid_cable's
+      # listener thread gone, everything else about the process still healthy.
+      ActionCable.server.stub(:pubsub, DeafPubsub.new) do
+        get cable_health_check_url
+      end
+    end
+
+    assert_response :service_unavailable
+    assert_equal 1, notified.size
+    assert_equal "Collab::RelayDown", notified.first[:error_class]
+  end
+
+  test "reports service unavailable when the subscription itself never confirms" do
+    notified = capture_notifications do
+      ActionCable.server.stub(:pubsub, UnreachablePubsub.new) do
+        get cable_health_check_url
+      end
+    end
+
+    assert_response :service_unavailable
+    assert_equal 1, notified.size
+  end
+
+  test "reports service unavailable rather than raising when the adapter errors" do
+    notified = capture_notifications do
+      ActionCable.server.stub(:pubsub, RaisingPubsub.new) do
+        get cable_health_check_url
+      end
+    end
+
+    assert_response :service_unavailable
+    assert_equal 1, notified.size
+  end
+
+  # Confirms the subscription is torn down however the check ends -- a per-request
+  # channel that leaked would leave the listener polling for it forever, once per
+  # health check.
+  test "unsubscribes its temporary channel on both success and failure" do
+    tracker = TrackingPubsub.new
+    ActionCable.server.stub(:pubsub, tracker) do
+      get cable_health_check_url
+    end
+    assert_equal tracker.subscribed, tracker.unsubscribed
+
+    deaf = DeafPubsub.new
+    capture_notifications do
+      ActionCable.server.stub(:pubsub, deaf) do
+        get cable_health_check_url
+      end
+    end
+    assert_equal deaf.subscribed, deaf.unsubscribed
+  end
+
+  # Records subscribe/unsubscribe pairs; delivers normally otherwise.
+  class TrackingPubsub
+    attr_reader :subscribed, :unsubscribed
+
+    def initialize
+      @subscribed = []
+      @unsubscribed = []
+    end
+
+    def subscribe(channel, callback, success_callback = nil)
+      @subscribed << channel
+      @callbacks ||= {}
+      @callbacks[channel] = callback
+      success_callback&.call
+    end
+
+    def unsubscribe(channel, _callback)
+      @unsubscribed << channel
+    end
+
+    def broadcast(channel, payload)
+      @callbacks[channel]&.call(payload)
+    end
+  end
+
+  # Subscribes fine, never delivers.
+  class DeafPubsub < TrackingPubsub
+    def broadcast(_channel, _payload)
+    end
+  end
+
+  # Never confirms the subscription.
+  class UnreachablePubsub < TrackingPubsub
+    def subscribe(channel, _callback, _success_callback = nil)
+      @subscribed << channel
+    end
+  end
+
+  # Cannot be reached at all.
+  class RaisingPubsub < TrackingPubsub
+    def subscribe(*)
+      raise ActiveRecord::ConnectionNotEstablished, "cable database is gone"
+    end
+  end
+
+  private
+
+    def capture_notifications
+      captured = []
+      Honeybadger.stub(:notify, ->(message, **options) { captured << options.merge(message: message) }) do
+        yield
+      end
+      captured
+    end
+end

--- a/test/controllers/collab_incidents_controller_test.rb
+++ b/test/controllers/collab_incidents_controller_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+class CollabIncidentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @project = projects(:one)
+    @user = users(:one)
+    sign_in @user
+  end
+
+  def report(params)
+    post collab_incidents_url, params: params, as: :json
+  end
+
+  test "accepts each reportable kind and notifies Honeybadger" do
+    CollabIncidentsController::KINDS.each do |kind|
+      notified = capture_notifications do
+        report(kind: kind, project_id: @project.id)
+      end
+
+      assert_response :accepted
+      assert_equal 1, notified.size, "expected #{kind} to notify once"
+      assert_equal "Collab::#{kind.camelize}", notified.first[:error_class]
+      assert_equal @project.id, notified.first[:context][:project_id]
+      assert_equal @user.id, notified.first[:context][:user_id]
+    end
+  end
+
+  test "rejects a kind that isn't one of the known few" do
+    notified = capture_notifications do
+      report(kind: "something_invented", project_id: @project.id)
+    end
+
+    assert_response :unprocessable_entity
+    assert_empty notified
+  end
+
+  test "accepts a report from a collaborator, not just the project owner" do
+    sign_out @user
+    # users(:two) collaborates on projects(:one) -- the reports worth having come
+    # from exactly this kind of session.
+    sign_in users(:two)
+
+    notified = capture_notifications do
+      report(kind: "relay_stalled", project_id: @project.id)
+    end
+
+    assert_response :accepted
+    assert_equal 1, notified.size
+  end
+
+  test "rejects a report about a project the reporter cannot edit" do
+    sign_out @user
+    sign_in users(:subscribed)
+
+    notified = capture_notifications do
+      report(kind: "relay_stalled", project_id: @project.id)
+    end
+
+    assert_response :forbidden
+    assert_empty notified
+  end
+
+  test "rejects a report about a project that does not exist" do
+    notified = capture_notifications do
+      report(kind: "relay_stalled", project_id: SecureRandom.uuid)
+    end
+
+    assert_response :forbidden
+    assert_empty notified
+  end
+
+  test "requires a signed-in reporter" do
+    sign_out @user
+
+    notified = capture_notifications do
+      report(kind: "relay_stalled", project_id: @project.id)
+    end
+
+    assert_response :unauthorized
+    assert_empty notified
+  end
+
+  test "carries the detail and silence duration into the report, truncating detail" do
+    detail = "x" * (CollabIncidentsController::MAX_DETAIL_LENGTH + 50)
+
+    notified = capture_notifications do
+      report(kind: "relay_stalled", project_id: @project.id, detail: detail, silent_for_seconds: "42")
+    end
+
+    context = notified.first[:context]
+    assert_equal 42, context[:silent_for_seconds]
+    assert_equal CollabIncidentsController::MAX_DETAIL_LENGTH, context[:detail].length
+  end
+
+  test "omits blank optional fields rather than reporting empty ones" do
+    notified = capture_notifications do
+      report(kind: "join_failed", project_id: @project.id)
+    end
+
+    context = notified.first[:context]
+    assert_not context.key?(:detail)
+    assert_not context.key?(:silent_for_seconds)
+  end
+
+  private
+
+    # Honeybadger is configured not to report in test (config/honeybadger.yml), so
+    # notifications are captured here rather than observed through the gem.
+    def capture_notifications
+      captured = []
+      Honeybadger.stub(:notify, ->(message, **options) { captured << options.merge(message: message) }) do
+        yield
+      end
+      captured
+    end
+end


### PR DESCRIPTION
## Why

Live collaboration broke in production, and **nothing we had noticed**. `/up` stayed green, no exception reached Honeybadger, autosave kept working, and we found out from users. A redeploy fixed it, which pointed at process state rather than at any of the week's commits — none of which touch the collaboration path.

The mechanism is in `solid_cable`'s listener thread — the thread that delivers every broadcast, polling the separate `cable` database:

```ruby
@thread = Thread.new do
  begin
    listen
  rescue *CONNECTION_ERRORS      # only ConnectionFailed / ConnectionTimeout / ConnectionNotEstablished
    retry if retry_connecting?   # ...and only a bounded number of times
  end
end
```

Two ways to lose it permanently: any error that isn't one of those three kills it outright, and those three kill it too once the retries run out. The retry budget is the problem — `reconnect_attempts` **defaults to `1`, which solid_cable expands to `[0]`: one retry, immediately, with no backoff.** A few seconds of managed-database failover is enough to spend it in every Puma worker at once.

Once that thread is gone the process serves every HTTP request perfectly and delivers no broadcast to anyone, forever, until it is restarted. Everything *else* about a collaborative session is ordinary HTTP on the primary database — joining, seeding, compaction, autosave — so from the server's side a session with a dead relay is indistinguishable from an idle one.

## What this does

Three layers, because the failure is invisible at each of the others.

### 1. Prevention — `config/cable.yml`

`reconnect_attempts: [0, 1, 2, 4, 8, 16, 32]`, so the listener rides out just over a minute of database unavailability instead of roughly zero. Not a cure: past that ceiling the process still needs a restart, which is what layer 2 is for.

### 2. Detection — `GET /up/cable`

`CableHealthController` publishes a token through the pubsub and waits to hear it back, so it fails exactly when the listener thread is gone.

Deliberately **not** folded into `/up`: an orchestrator restarting the app every time the cable database blinked would be a worse outage than the one this catches. Point a monitor at it and alert.

One caveat: it reports on *the process that served the request*. Under multiple Puma workers a single wedged worker shows up as intermittent failures, not steady ones — so treat any failure as real.

### 3. Reporting — a client watchdog

`YCableProvider` now watches for the relay going quiet. The channel broadcasts to every subscriber *including the sender*, so each client's own awareness heartbeat comes back to it every 15s: a healthy relay cannot be silent for 37.5s no matter how idle the humans are. Silence is a positive signal, and it works in a session of one as well as a session of five.

On a stall it warns the user, reports the incident, and **falls back to polling the doc over HTTP**. That last part is the useful bit — only the broadcast leg dies, so `doc_update` is still reaching the server and still being appended to `project_doc_updates`. Polling turns a silently diverging session into a merely slow one. Recovery is reported too, with its duration; a stall that never recovers is the one that needs a restart.

Reports go to `CollabIncidentsController` (authenticated, rate-limited, fixed vocabulary of kinds) which forwards them to Honeybadger — there is no JavaScript error tracker in this app, and routing through Ruby also keeps the API key out of the bundle.

## Setting up the Honeybadger alerts

The code reports; **the alerts have to be created in Honeybadger by hand.** Nothing below is automatic.

Four error classes, one per failure, so each can be alerted on separately:

| Error class | Raised by | What it means | Suggested response |
|---|---|---|---|
| `Collab::RelayDown` | `/up/cable` (server) | This process is not delivering broadcasts. The listener thread is almost certainly dead. | **Page.** Restart the app. |
| `Collab::RelayStalled` | Editor watchdog (browser) | A real session went ≥37.5s without a single cable message. | **Page** if more than one user, or if no `RelayRecovered` follows. |
| `Collab::JoinFailed` | Editor (browser) | Someone could not join a collaborative session at all. | Alert on a burst; a lone one is usually a flaky network. |
| `Collab::RelayRecovered` | Editor watchdog (browser) | A stall ended on its own. Includes how long it lasted. | Don't page. Read it — it's what distinguishes a blip from a wedged process. |

**In Honeybadger** (Project → Alerts & Integrations):

1. Create an alert for `Collab::RelayDown`, "on every occurrence", to whatever pages you. This is the one that means "restart something now".
2. Create an alert for `Collab::RelayStalled`. If you want to avoid being paged for one user's flaky wifi, set a threshold of 2+ occurrences in 10 minutes instead of every occurrence.
3. Create an alert for `Collab::JoinFailed` with a threshold — say 5 in 15 minutes.
4. Leave `Collab::RelayRecovered` unalerted but **not** muted. When a page fires, the presence or absence of a matching `RelayRecovered` is the fastest way to tell "the database blipped and we healed" from "a worker is deaf and staying that way".

Every report carries `project_id`, `user_id`, `user_agent`, and where applicable `silent_for_seconds` and a `detail` string; `Collab::RelayDown` carries `pid`, `hostname` and the configured adapter, which is what identifies *which* worker to blame.

Nothing needs to change in `config/honeybadger.yml` — the existing API key and the standard `development`/`test` exclusions already cover this.

## Setting up the uptime monitor

Point whatever you already use at:

```
https://pretext.plus/up/cable
```

- Expect **200** with a body like `ok (relay round-tripped in 12ms)`; it returns **503** on failure.
- Every 60s is plenty. The endpoint is rate-limited to 60/min per IP and holds a request thread for at most 3s.
- Unauthenticated, like `/up`, so a monitor can reach it.
- Alert on two consecutive failures rather than one, since a single wedged worker among several will only be hit some of the time.

## Testing

- `bin/rails test` — 656 runs, 0 failures
- `bin/rails test:system` — 10 runs, 0 failures (includes `collaborative_editing_test`)
- 14 new tests across the two controllers, covering the happy path, a pubsub that subscribes but never delivers (the exact shape of the outage), a pubsub that never confirms the subscription, an adapter that raises, subscription teardown on every path, and the incident endpoint's authorization and validation.
- Verified `config_for("cable")` under `-e production` yields `reconnect_attempts=[0, 1, 2, 4, 8, 16, 32]`.

The browser-side watchdog is not covered by a system test — faithfully simulating "cable connected but silent" in Capybara isn't something I could do honestly, so the logic is kept deliberately small and readable instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
